### PR TITLE
Remove inline tooltip style

### DIFF
--- a/ui/components/src/InfoTooltip/InfoTooltip.tsx
+++ b/ui/components/src/InfoTooltip/InfoTooltip.tsx
@@ -94,13 +94,8 @@ const StyledTooltip = styled(({ className, ...props }: MuiTooltipProps) => (
   <MuiTooltip {...props} classes={{ popper: className }} />
 ))(({ theme }) => ({
   [`& .${tooltipClasses.tooltip}`]: {
-    backgroundColor: theme.palette.background.tooltip,
-    color: theme.palette.text.primary,
     maxWidth: '300px',
     padding: theme.spacing(1),
     boxShadow: theme.shadows[1],
-  },
-  [`& .${tooltipClasses.arrow}`]: {
-    color: theme.palette.background.tooltip,
   },
 }));


### PR DESCRIPTION
This pull request includes a change to the `InfoTooltip` component in the `ui/components/src/InfoTooltip/InfoTooltip.tsx` file. The change removes specific styling for the tooltip's background color and text color, as well as the arrow color, to simplify the component's appearance.

Styling changes:

* [`ui/components/src/InfoTooltip/InfoTooltip.tsx`](diffhunk://#diff-c5b4d1dbefc38cbdc1036762b35726bd90fa2fdf17db4deb23f8a94cf1cd8dd4L97-L105): Removed the background color and text color styling for the tooltip, and the color styling for the tooltip's arrow.