### PR TITLE
Improve text in ui

### DIFF
--- a/ui/components/src/FormatControls/FormatControls.tsx
+++ b/ui/components/src/FormatControls/FormatControls.tsx
@@ -94,7 +94,7 @@ export function FormatControls({ value, onChange, disabled = false }: FormatCont
   return (
     <>
       <OptionsEditorControl
-        label="Short values"
+        label="Abbreviate values"
         control={
           <Switch
             checked={hasShortValues ? shouldShortenValues(value.shortValues) : false}

--- a/ui/components/src/LinksEditor/LinksEditor.tsx
+++ b/ui/components/src/LinksEditor/LinksEditor.tsx
@@ -44,7 +44,7 @@ export function LinksEditor({ control, ...props }: LinksEditorProps): ReactEleme
         ))
       ) : (
         <Typography variant="subtitle1" mb={2} fontStyle="italic">
-          No links defined
+          Add reference links to related dashboards or external resources. No links have been added yet.
         </Typography>
       )}
       <IconButton

--- a/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
+++ b/ui/dashboards/src/components/Datasources/DatasourceEditor.tsx
@@ -64,7 +64,7 @@ export function DatasourceEditor(props: {
           closeDiscardChangesConfirmationDialog();
         },
         description:
-          'You have unapplied changes. Are you sure you want to discard these changes? Changes cannot be recovered.',
+          'You have unsaved changes in this panel. Are you sure you want to discard them? This action can’t be undone.',
       });
     } else {
       props.onCancel();

--- a/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
+++ b/ui/dashboards/src/components/DiscardChangesConfirmationDialog/DiscardChangesConfirmationDialog.tsx
@@ -24,7 +24,7 @@ export const DashboardDiscardChangesConfirmationDialog = (): ReactElement | null
     <DiscardChangesConfirmationDialog
       description={
         dialog.description ||
-        'You have unsaved changes in this dashboard. Are you sure you want to discard these changes? Changes cannot be recovered.'
+        'You have unsaved changes in this dashboard. Are you sure you want to discard them? This action can’t be undone.'
       }
       isOpen={true}
       onCancel={dialog.onCancel}

--- a/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx
@@ -166,7 +166,7 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
                   {...field}
                   required
                   fullWidth
-                  label="Group"
+                  label="Panel group"
                   error={!!fieldState.error}
                   helperText={fieldState.error?.message}
                   onChange={(event) => {
@@ -212,7 +212,7 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
                   pluginTypes={['Panel']}
                   required
                   fullWidth
-                  label="Type"
+                  label="Visualization type"
                   disabled={pluginEditor.isLoading}
                   error={!!pluginEditor.error || !!fieldState.error}
                   helperText={pluginEditor.error?.message ?? fieldState.error?.message}
@@ -251,7 +251,7 @@ export function PanelEditorForm(props: PanelEditorFormProps): ReactElement {
         </Grid>
       </Box>
       <DiscardChangesConfirmationDialog
-        description="You have unapplied changes in this panel. Are you sure you want to discard these changes? Changes cannot be recovered."
+        description="You have unsaved changes in this panel. Are you sure you want to discard them? This action can’t be undone."
         isOpen={isDiscardDialogOpened}
         onCancel={() => {
           setDiscardDialogOpened(false);

--- a/ui/dashboards/src/components/Variables/VariableEditor.tsx
+++ b/ui/dashboards/src/components/Variables/VariableEditor.tsx
@@ -101,7 +101,7 @@ export function VariableEditor(props: {
           closeDiscardChangesConfirmationDialog();
         },
         description:
-          'You have unapplied changes. Are you sure you want to discard these changes? Changes cannot be recovered.',
+          'You have unsaved changes in this panel. Are you sure you want to discard them? This action can’t be undone.',
       });
     } else {
       props.onCancel();

--- a/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
+++ b/ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx
@@ -153,7 +153,7 @@ export function LegendOptionsEditor({
         }
       />
       <OptionsEditorControl
-        label="Mode"
+        label="Display"
         control={
           <SettingsAutocomplete
             value={{
@@ -186,7 +186,7 @@ export function LegendOptionsEditor({
       />
       {showValuesEditor && (
         <OptionsEditorControl
-          label="Values"
+          label="Table values"
           control={
             // For some reason, the inferred option type doesn't always seem to work
             // quite right when `multiple` is true. Explicitly setting the generics


### PR DESCRIPTION
This pull request includes several changes to the labels and descriptions in various components to improve clarity and user experience. The changes span multiple files within the `ui` directory, focusing on making the language more user-friendly and consistent.

Label and Description Updates:

* [`ui/components/src/FormatControls/FormatControls.tsx`](diffhunk://#diff-fd3ddb74d4c436c8e25bdda57e6a523ae4af8b921f7861c5bc412f64976ecefbL97-R97): Changed the label "Short values" to "Abbreviate values" for better clarity.
* [`ui/components/src/LinksEditor/LinksEditor.tsx`](diffhunk://#diff-a30e1413a58ce71a9d824c5d8d95a793834b9eb27cf01a5d1674c5db7978111eL47-R47): Updated the no links message to "Add reference links to related dashboards or external resources. No links have been added yet." to provide more context.
* [`ui/dashboards/src/components/Datasources/DatasourceEditor.tsx`](diffhunk://#diff-94850cea52488332c9d8d0fc3c51cd27f4bf6dd0a4deed259f9cc750ccc70ba4L67-R67): Modified the discard changes confirmation dialog description to "You have unsaved changes in this panel. Are you sure you want to discard them? This action can’t be undone." for consistency.
* [`ui/dashboards/src/components/PanelDrawer/PanelEditorForm.tsx`](diffhunk://#diff-88c92b0c27c23e16dc0d910c58fea9224e1a49fb415880ab4a610cdc391a045eL169-R169): Updated several labels, including changing "Group" to "Panel group" and "Type" to "Visualization type". Also updated the discard changes confirmation dialog description for consistency. [[1]](diffhunk://#diff-88c92b0c27c23e16dc0d910c58fea9224e1a49fb415880ab4a610cdc391a045eL169-R169) [[2]](diffhunk://#diff-88c92b0c27c23e16dc0d910c58fea9224e1a49fb415880ab4a610cdc391a045eL215-R215) [[3]](diffhunk://#diff-88c92b0c27c23e16dc0d910c58fea9224e1a49fb415880ab4a610cdc391a045eL254-R254)
* [`ui/plugin-system/src/components/LegendOptionsEditor/LegendOptionsEditor.tsx`](diffhunk://#diff-427c307c9e95f01fc5549140296d7e77d223e251db5de97165ace92ed9e8dd44L156-R156): Changed labels "Mode" to "Display" and "Values" to "Table values" to improve clarity. [[1]](diffhunk://#diff-427c307c9e95f01fc5549140296d7e77d223e251db5de97165ace92ed9e8dd44L156-R156) [[2]](diffhunk://#diff-427c307c9e95f01fc5549140296d7e77d223e251db5de97165ace92ed9e8dd44L189-R189)