### PR TITLE
APPZ-498 UniDash - Fix shared tooltip in edit mode

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -108,8 +108,14 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
   },
   ref
 ) {
-  const { chartsTheme, enablePinning, lastTooltipPinnedCoords, setLastTooltipPinnedCoords, pointActions } =
-    useChartsContext();
+  const {
+    chartsTheme,
+    enablePinning,
+    lastTooltipPinnedCoords,
+    setLastTooltipPinnedCoords,
+    pointActions,
+    enableSyncGrouping,
+  } = useChartsContext();
   const isPinningEnabled = tooltipConfig.enablePinning && enablePinning;
   const chartRef = useRef<EChartsInstance>();
   const [showTooltip, setShowTooltip] = useState<boolean>(true);
@@ -449,7 +455,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
         theme={chartsTheme.echartsTheme}
         onEvents={handleEvents}
         _instance={chartRef}
-        syncGroup={syncGroup}
+        syncGroup={enableSyncGrouping ? syncGroup : undefined}
       />
     </Box>
   );

--- a/ui/components/src/context/ChartsProvider.tsx
+++ b/ui/components/src/context/ChartsProvider.tsx
@@ -18,6 +18,7 @@ import { CursorCoordinates, PointAction } from '../TimeSeriesTooltip';
 export interface ChartsProviderProps {
   chartsTheme: PersesChartsTheme;
   enablePinning?: boolean;
+  enableSyncGrouping?: boolean;
   children?: React.ReactNode;
   pointActions?: PointAction[];
 }
@@ -25,13 +26,14 @@ export interface ChartsProviderProps {
 export interface SharedChartsState {
   chartsTheme: PersesChartsTheme;
   enablePinning: boolean;
+  enableSyncGrouping: boolean;
   lastTooltipPinnedCoords: CursorCoordinates | null;
   setLastTooltipPinnedCoords: (lastTooltipPinnedCoords: CursorCoordinates | null) => void;
   pointActions: PointAction[];
 }
 
 export function ChartsProvider(props: ChartsProviderProps): ReactElement {
-  const { children, chartsTheme, enablePinning = false, pointActions = [] } = props;
+  const { children, chartsTheme, enablePinning = false, pointActions = [], enableSyncGrouping = true } = props;
 
   const [lastTooltipPinnedCoords, setLastTooltipPinnedCoords] = useState<CursorCoordinates | null>(null);
 
@@ -42,8 +44,16 @@ export function ChartsProvider(props: ChartsProviderProps): ReactElement {
       lastTooltipPinnedCoords,
       setLastTooltipPinnedCoords,
       pointActions,
+      enableSyncGrouping,
     };
-  }, [chartsTheme, enablePinning, lastTooltipPinnedCoords, setLastTooltipPinnedCoords, pointActions]);
+  }, [
+    chartsTheme,
+    enablePinning,
+    lastTooltipPinnedCoords,
+    setLastTooltipPinnedCoords,
+    pointActions,
+    enableSyncGrouping,
+  ]);
 
   return <ChartsThemeContext.Provider value={ctx}>{children}</ChartsThemeContext.Provider>;
 }

--- a/ui/components/src/test-utils/theme.ts
+++ b/ui/components/src/test-utils/theme.ts
@@ -44,4 +44,5 @@ export const mockChartsContext: SharedChartsState = {
   lastTooltipPinnedCoords: null,
   setLastTooltipPinnedCoords: () => null,
   pointActions: [],
+  enableSyncGrouping: true,
 };

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -144,7 +144,7 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
             }}
           />
         </ErrorBoundary>
-        <ChartsProvider chartsTheme={chartsTheme} enablePinning={false}>
+        <ChartsProvider chartsTheme={chartsTheme} enablePinning={false} enableSyncGrouping={false}>
           <PanelDrawer />
         </ChartsProvider>
         <PanelGroupDialog />


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Shared tooltip used to be shown whenever editing on-top of the edit panel.

<!-- Context useful to a reviewer -->

# Screenshots

**BEFORE**
![before](https://github.com/user-attachments/assets/7454da79-5c34-4e4f-88f9-5328c823a494)


**AFTER**
![after](https://github.com/user-attachments/assets/70fbc92b-3dc1-41b9-a947-e8484f6f07aa)


<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
