### PR TITLE
APPZ-507 UniDash - Support variable usage from other variables

### DIFF
--- a/ui/plugin-system/src/components/Variables/variable-model.ts
+++ b/ui/plugin-system/src/components/Variables/variable-model.ts
@@ -51,11 +51,15 @@ export function useListVariablePluginValues(definition: ListVariableDefinition):
   const capturingRegexp =
     definition.spec.capturingRegexp !== undefined ? new RegExp(definition.spec.capturingRegexp, 'g') : undefined;
 
-  let dependsOnVariables: string[] | undefined;
+  // LOGZ.IO CHANGE START:: Support variables from variables [APPZ-507]
+  let dependsOnVariables: string[] = Object.keys(allVariables); // Default to all variables
   if (variablePlugin?.dependsOn) {
     const dependencies = variablePlugin.dependsOn(spec, variablePluginCtx);
-    dependsOnVariables = dependencies.variables;
+    dependsOnVariables = dependencies.variables ? dependencies.variables : dependsOnVariables;
   }
+  // Exclude self variable to avoid circular dependency
+  dependsOnVariables = dependsOnVariables.filter((v) => v !== definition.spec.name);
+  // LOGZ.IO CHANGE END:: Support variables from variables [APPZ-507]
 
   const variables = useAllVariableValues(dependsOnVariables);
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
This is a bug fix regarding self-referencing variables

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.
