### PR TITLE
APPZ-364 Change refresh interval options

### DIFF
--- a/ui/plugin-system/src/components/TimeRangeControls/TimeRangeControls.tsx
+++ b/ui/plugin-system/src/components/TimeRangeControls/TimeRangeControls.tsx
@@ -35,14 +35,19 @@ import {
   useShowZoomRangeSetting,
 } from '../../runtime';
 
+// LOGZ.IO CHANGE START:: Change refresh time interval options [APPZ-364]
 export const DEFAULT_REFRESH_INTERVAL_OPTIONS: TimeOption[] = [
   { value: { pastDuration: '0s' }, display: 'Off' },
-  { value: { pastDuration: '5s' }, display: '5s' },
-  { value: { pastDuration: '10s' }, display: '10s' },
-  { value: { pastDuration: '15s' }, display: '15s' },
   { value: { pastDuration: '30s' }, display: '30s' },
-  { value: { pastDuration: '60s' }, display: '1m' },
+  { value: { pastDuration: '1m' }, display: '1m' },
+  { value: { pastDuration: '5m' }, display: '5m' },
+  { value: { pastDuration: '15m' }, display: '15m' },
+  { value: { pastDuration: '30m' }, display: '30m' },
+  { value: { pastDuration: '1h' }, display: '1h' },
+  { value: { pastDuration: '2h' }, display: '2h' },
+  { value: { pastDuration: '1d' }, display: '1d' },
 ];
+// LOGZ.IO CHANGE END:: Change refresh time interval options [APPZ-364]
 
 const DEFAULT_HEIGHT = '34px';
 


### PR DESCRIPTION
This pull request updates the default refresh time interval options in the `TimeRangeControls` component to provide a broader range of durations.

### Updates to refresh time interval options:
* [`ui/plugin-system/src/components/TimeRangeControls/TimeRangeControls.tsx`](diffhunk://#diff-562fe52481dc86bf7a4e1230eeb050e1ece0c7b8f049ee099fe947029b1b6766R38-R50): Replaced shorter intervals (5s, 10s, 15s, 60s) with longer intervals (5m, 15m, 30m, 1h, 2h, 1d) to better suit use cases requiring extended timeframes.