### PR TITLE
APPZ-1218 APPZ-1219 Custom Bar and Pie chart tooltip

### DIFF
--- a/ui/components/src/BarChart/BarChart.tsx
+++ b/ui/components/src/BarChart/BarChart.tsx
@@ -13,7 +13,7 @@
 
 import { ReactElement, useMemo } from 'react';
 import { FormatOptions, formatValue } from '@perses-dev/core';
-import { use, EChartsCoreOption } from 'echarts/core';
+import { use, EChartsCoreOption, ECharts as EChartsInstance } from 'echarts/core';
 import { BarChart as EChartsBarChart } from 'echarts/charts';
 import { GridComponent, DatasetComponent, TitleComponent, TooltipComponent } from 'echarts/components';
 import { CanvasRenderer } from 'echarts/renderers';
@@ -39,10 +39,24 @@ export interface BarChartProps {
   data: BarChartData[] | null;
   format?: FormatOptions;
   mode?: ModeOption;
+  // LOGZ.IO CHANGE START:: APPZ-1218 US2 – Bar Chart
+  useDefaultTooltip?: boolean;
+  _instance?: React.MutableRefObject<EChartsInstance | undefined>;
+  // LOGZ.IO CHANGE END:: APPZ-1218 US2 – Bar Chart
 }
 
 export function BarChart(props: BarChartProps): ReactElement {
-  const { width, height, data, format = { unit: 'decimal' }, mode = 'value' } = props;
+  const {
+    width,
+    height,
+    data,
+    format = { unit: 'decimal' },
+    mode = 'value',
+    // LOGZ.IO CHANGE START:: APPZ-1218 US2 – Bar Chart
+    _instance,
+    useDefaultTooltip = true,
+    // LOGZ.IO CHANGE END:: APPZ-1218 US2 – Bar Chart
+  } = props;
   const chartsTheme = useChartsTheme();
 
   const option: EChartsCoreOption = useMemo(() => {
@@ -100,19 +114,22 @@ export function BarChart(props: BarChartProps): ReactElement {
           color: chartsTheme.echartsTheme[0],
         },
       },
-      tooltip: {
-        appendToBody: true,
-        confine: true,
-        formatter: (params: { name: string; data: number[] }) =>
-          params.data[1] && `<b>${params.name}</b> &emsp; ${formatValue(params.data[1], format)}`,
-      },
+      // LOGZ.IO CHANGE: APPZ-1218 US2 – Bar Chart
+      tooltip: useDefaultTooltip
+        ? {
+            appendToBody: true,
+            confine: true,
+            formatter: (params: { name: string; data: number[] }) =>
+              params.data[1] && `<b>${params.name}</b> &emsp; ${formatValue(params.data[1], format)}`,
+          }
+        : undefined,
       // increase distance between grid and container to prevent y axis labels from getting cut off
       grid: {
         left: '5%',
         right: '5%',
       },
     };
-  }, [data, chartsTheme, width, mode, format]);
+  }, [data, chartsTheme, width, mode, format, useDefaultTooltip]);
 
   return (
     <Box
@@ -129,6 +146,8 @@ export function BarChart(props: BarChartProps): ReactElement {
         }}
         option={option}
         theme={chartsTheme.echartsTheme}
+        // LOGZ.IO CHANGE: APPZ-1218 US2 – Bar Chart
+        _instance={_instance}
       />
     </Box>
   );

--- a/ui/components/src/PieChart/PieChart.tsx
+++ b/ui/components/src/PieChart/PieChart.tsx
@@ -23,6 +23,7 @@ import {
 import { CanvasRenderer } from 'echarts/renderers';
 import { Box } from '@mui/material';
 import { ReactElement } from 'react';
+import type { ECharts as EChartsInstance } from 'echarts/core';
 import { useChartsTheme } from '../context/ChartsProvider';
 import { EChart } from '../EChart';
 
@@ -41,17 +42,33 @@ export interface PieChartProps {
   data: PieChartData[] | null;
   label?: string;
   legend?: LegendComponentOption;
+  // LOGZ.IO CHANGE START:: APPZ-1218 US2 – Pie Chart
+  useDefaultTooltip?: boolean;
+  _instance?: React.MutableRefObject<EChartsInstance | undefined>;
+  // LOGZ.IO CHANGE END:: APPZ-1218 US2 – Pie Chart
 }
 
 export function PieChart(props: PieChartProps): ReactElement {
-  const { width, height, data, label } = props;
+  const {
+    width,
+    height,
+    data,
+    label,
+    // LOGZ.IO CHANGE START:: APPZ-1218 US2 – Pie Chart
+    _instance,
+    useDefaultTooltip = true,
+    // LOGZ.IO CHANGE END:: APPZ-1218 US2 – Pie Chart
+  } = props;
   const chartsTheme = useChartsTheme();
 
   const option: EChartsCoreOption = {
-    tooltip: {
-      trigger: 'item',
-      formatter: label ? '{a} <br/>{b} : {c} ({d}%)' : '{b} : {c} ({d}%)',
-    },
+    // LOGZ.IO CHANGE: APPZ-1218 US2 – Pie Chart
+    tooltip: useDefaultTooltip
+      ? {
+          trigger: 'item',
+          formatter: label ? '{a} <br/>{b} : {c} ({d}%)' : '{b} : {c} ({d}%)',
+        }
+      : undefined,
     axisLabel: {
       overflow: 'truncate',
       width: width / 3,
@@ -94,6 +111,8 @@ export function PieChart(props: PieChartProps): ReactElement {
         }}
         option={option}
         theme={chartsTheme.echartsTheme}
+        // LOGZ.IO CHANGE: APPZ-1218 US2 – Pie Chart
+        _instance={_instance}
       />
     </Box>
   );


### PR DESCRIPTION
Disable standard tooltip and expose an instance of the echart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add optional tooltip disabling and ECharts instance exposure to BarChart and PieChart via new props.
> 
> - **Charts**:
>   - **`BarChart`**:
>     - Add `useDefaultTooltip` (default `true`) and `_instance` props.
>     - Conditionally configure `tooltip`; pass `_instance` to `EChart`.
>     - Import `EChartsInstance`; update memo deps.
>   - **`PieChart`**:
>     - Add `useDefaultTooltip` (default `true`) and `_instance` props.
>     - Conditionally configure `tooltip`; pass `_instance` to `EChart`.
>     - Import `EChartsInstance`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea63cd34f387bbbc6785128c9f3a4f9b2d72a5bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->