### PR TITLE
APPZ-709 Preview custom drilldown from panel editor

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/LineChartTooltip.tsx
+++ b/ui/components/src/TimeSeriesTooltip/LineChartTooltip.tsx
@@ -109,8 +109,10 @@ export const LineChartTooltip = memo(function LineChartTooltip({
           visibility: 'visible',
           opacity: 1,
           transition: 'all 0.1s ease-out',
-          // Ensure pinned tooltip shows behind edit panel drawer and sticky header
-          zIndex: pinnedPos !== null ? 'auto' : theme.zIndex.tooltip,
+          // LOGZ.IO CHANGE START:: Custom Drilldown preview [APPZ-709]
+          // Ensure pinned tooltip shows on top of all content, especially in panel editor
+          zIndex: pinnedPos !== null ? theme.zIndex.modal + 1 : theme.zIndex.tooltip,
+          // LOGZ.IO CHANGE END:: Custom Drilldown preview [APPZ-709]
           overflow: 'hidden',
           '&:hover': {
             overflowY: 'auto',

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -112,8 +112,10 @@ export function getTooltipStyles(
     border: `1px solid ${theme.palette.grey['200']}`,
     boxShadow: theme.shadows[4],
     // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
-    // Ensure pinned tooltip shows behind edit panel drawer and sticky header
-    zIndex: pinnedPos !== null ? 'auto' : theme.zIndex.tooltip,
+    // LOGZ.IO CHANGE START:: Custom Drilldown preview [APPZ-709]
+    // Ensure pinned tooltip shows on top of all content, especially in panel editor
+    zIndex: pinnedPos !== null ? theme.zIndex.modal + 1 : theme.zIndex.tooltip,
+    // LOGZ.IO CHANGE END:: Custom Drilldown preview [APPZ-709]
     overflow: 'hidden',
     '&:hover': {
       overflowY: 'auto',

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -13,7 +13,7 @@
 
 import { ReactElement, useState, useEffect } from 'react';
 import { Box } from '@mui/material';
-import { ChartsProvider, ErrorAlert, ErrorBoundary, useChartsTheme } from '@perses-dev/components';
+import { ChartsProvider, ErrorAlert, ErrorBoundary, useChartsTheme, useChartsContext } from '@perses-dev/components';
 import { DashboardResource, EphemeralDashboardResource } from '@perses-dev/core';
 import { useDatasourceStore } from '@perses-dev/plugin-system';
 import {
@@ -62,6 +62,7 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
   } = props;
 
   const chartsTheme = useChartsTheme();
+  const parentChartsContext = useChartsContext(); // LOGZ.IO CHANGE:: Custom Drilldown preview [APPZ-709]
 
   const { isEditMode, setEditMode } = useEditMode();
   const { dashboard, setDashboard } = useDashboard();
@@ -146,8 +147,9 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
         </ErrorBoundary>
         <ChartsProvider
           chartsTheme={chartsTheme}
-          enablePinning={false}
+          enablePinning={true} // LOGZ.IO CHANGE:: Custom Drilldown preview [APPZ-709]
           enableSyncGrouping={false} // LOGZ.IO CHANGE:: Shared tooltip in edit panel bug-fix [APPZ-498]
+          pointActions={parentChartsContext.pointActions || []} // LOGZ.IO CHANGE:: Custom Drilldown preview [APPZ-709]
         >
           <PanelDrawer />
         </ChartsProvider>


### PR DESCRIPTION
### **Enable custom drilldowns in the panel editor**
This PR introduces small but crucial changes to enable a custom drilldown feature (via `pointActions`) within the panel editor. The goal is to ensure that chart tooltips and their custom actions behave consistently between the main dashboard view and the editor drawer.

The following key changes were made:

* **Propagate `pointActions` to the Panel Editor:** The `DashboardApp` now reads the parent `ChartsContext` and passes the `pointActions` to its nested `ChartsProvider`. This makes custom drilldown actions available in the panel editor without prop drilling.

* **Enable Tooltip Pinning in the Panel Editor:** `enablePinning` is now set to `true` for the editor's `ChartsProvider`. This is a necessary step to allow users to click and interact with the `pointActions` on a pinned tooltip.

* **Fix Pinned Tooltip Layering (`z-index`):** The `z-index` for pinned tooltips has been increased to `theme.zIndex.modal + 1`. This resolves a visual bug where the pinned tooltip would render behind the panel editor drawer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables pinned tooltips with custom drilldown actions in the panel editor and raises tooltip z-index above the editor.
> 
> - **Dashboards**:
>   - **Panel Editor**: In `ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx`
>     - Enable `enablePinning` on nested `ChartsProvider`.
>     - Propagate `pointActions` from parent `ChartsContext` to the editor `ChartsProvider`.
> - **Components**:
>   - **Tooltip Layering**: In `ui/components/src/TimeSeriesTooltip/LineChartTooltip.tsx` and `ui/components/src/TimeSeriesTooltip/utils.ts`
>     - Set pinned tooltip `zIndex` to `theme.zIndex.modal + 1` to ensure it appears above the editor drawer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db80fa66d4e942d80f9e212d39f6a9b90d50d86f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->