### PR TITLE
APPZ-1418 Improve tooltip behavior

### DIFF
--- a/ui/components/src/PieChart/PieChart.tsx
+++ b/ui/components/src/PieChart/PieChart.tsx
@@ -25,8 +25,8 @@ import { Box } from '@mui/material';
 import { ReactElement } from 'react';
 import type { ECharts as EChartsInstance } from 'echarts/core';
 import { useChartsTheme } from '../context/ChartsProvider';
-import { EChart } from '../EChart';
-
+// LOGZ.IO CHANGE START:: Tooltip is not behaving correctly [APPZ-1418]
+import { EChart, OnEventsType } from '../EChart';
 use([EChartsPieChart, GridComponent, DatasetComponent, TitleComponent, TooltipComponent, CanvasRenderer]);
 
 const PIE_WIN_WIDTH = 12;
@@ -45,6 +45,7 @@ export interface PieChartProps {
   // LOGZ.IO CHANGE START:: APPZ-1218 US2 – Pie Chart
   useDefaultTooltip?: boolean;
   _instance?: React.MutableRefObject<EChartsInstance | undefined>;
+  onEvents?: OnEventsType<unknown>;
   // LOGZ.IO CHANGE END:: APPZ-1218 US2 – Pie Chart
 }
 
@@ -57,6 +58,7 @@ export function PieChart(props: PieChartProps): ReactElement {
     // LOGZ.IO CHANGE START:: APPZ-1218 US2 – Pie Chart
     _instance,
     useDefaultTooltip = true,
+    onEvents,
     // LOGZ.IO CHANGE END:: APPZ-1218 US2 – Pie Chart
   } = props;
   const chartsTheme = useChartsTheme();
@@ -111,8 +113,10 @@ export function PieChart(props: PieChartProps): ReactElement {
         }}
         option={option}
         theme={chartsTheme.echartsTheme}
-        // LOGZ.IO CHANGE: APPZ-1218 US2 – Pie Chart
+        // LOGZ.IO CHANGE START:: APPZ-1218 US2 – Pie Chart
         _instance={_instance}
+        onEvents={onEvents}
+        // LOGZ.IO CHANGE END:: APPZ-1218 US2 – Pie Chart
       />
     </Box>
   );

--- a/ui/components/src/PieChart/PieChart.tsx
+++ b/ui/components/src/PieChart/PieChart.tsx
@@ -25,7 +25,7 @@ import { Box } from '@mui/material';
 import { ReactElement } from 'react';
 import type { ECharts as EChartsInstance } from 'echarts/core';
 import { useChartsTheme } from '../context/ChartsProvider';
-// LOGZ.IO CHANGE START:: Tooltip is not behaving correctly [APPZ-1418]
+// LOGZ.IO CHANGE:: Tooltip is not behaving correctly [APPZ-1418]
 import { EChart, OnEventsType } from '../EChart';
 use([EChartsPieChart, GridComponent, DatasetComponent, TitleComponent, TooltipComponent, CanvasRenderer]);
 

--- a/ui/components/src/TimeSeriesTooltip/TooltipActions.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipActions.tsx
@@ -21,7 +21,7 @@ import {
   TOOLTIP_BG_COLOR_FALLBACK,
   TOOLTIP_MAX_WIDTH,
 } from './tooltip-model';
-import { NearbySeriesInfo } from './nearby-series';
+import { NearbySeriesInfo } from './types';
 
 export interface TooltipActionProps {
   actions: PointAction[];

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
@@ -13,7 +13,7 @@
 
 import { ReactElement, useMemo } from 'react';
 import { Box } from '@mui/material';
-import { NearbySeriesArray } from './nearby-series';
+import { NearbySeriesArray } from './types';
 import { SeriesInfo } from './SeriesInfo';
 
 export interface TooltipContentProps {

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.tsx
@@ -15,7 +15,7 @@ import { Box, Typography, Stack, Switch, IconButton } from '@mui/material';
 import { memo, ReactElement } from 'react';
 import Close from 'mdi-material-ui/Close';
 import { getDateAndTime } from '../utils';
-import { NearbySeriesArray } from './nearby-series';
+import { NearbySeriesArray } from './types';
 import { TOOLTIP_BG_COLOR_FALLBACK, TOOLTIP_MAX_WIDTH } from './tooltip-model';
 
 export interface TooltipHeaderProps {

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.test.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.test.ts
@@ -99,7 +99,8 @@ describe('getYBuffer', () => {
   });
 
   it('should return area to search for larger interval', () => {
-    expect(getYBuffer({ yInterval: 10, totalSeries: 10, showAllSeries: false })).toBe(30);
+    // LOGZ.IO CHANGE:: Tooltip is not behaving correctly [APPZ-1418]
+    expect(getYBuffer({ yInterval: 10, totalSeries: 10, showAllSeries: false })).toBe(10);
   });
 
   it('should return entire canvas for larger interval', () => {

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -67,7 +67,6 @@ export function checkforNearbyTimeSeries(
     chart,
     mousePixelX,
     seriesMetadata,
-    format,
     selectedSeriesIdx,
   });
 
@@ -85,7 +84,7 @@ export function checkforNearbyTimeSeries(
     emphasizedDatapoints,
     duplicateDatapoints,
     nearbySeriesIndexes,
-  } = processCandidates(candidates, winner);
+  } = processCandidates(candidates, winner, format);
 
   // LOGZ.IO CHANGE END:: Tooltip is not behaving correctly [APPZ-1418]
 

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -17,6 +17,13 @@ import { formatValue, TimeSeriesValueTuple, FormatOptions, TimeSeries, TimeSerie
 import { EChartsDataFormat, OPTIMIZED_MODE_SERIES_LIMIT, TimeChartSeriesMapping, DatapointInfo } from '../model';
 import { batchDispatchNearbySeriesActions, getPointInGrid, getClosestTimestamp } from '../utils';
 import { CursorCoordinates, CursorData, EMPTY_TOOLTIP_DATA } from './tooltip-model';
+import {
+  calculateBarBandwidth,
+  calculateBarSegmentBounds,
+  calculateBarYBounds,
+  calculateVisualYForSeries,
+  getPixelXFromGrid,
+} from './utils';
 
 // LOGZ.IO CHANGE START:: Tooltip is not behaving correctly [APPZ-1418]
 
@@ -40,25 +47,13 @@ export interface NearbySeriesInfo {
 }
 
 export type NearbySeriesArray = NearbySeriesInfo[];
-type Candidate = {
+
+type Candidate = Omit<NearbySeriesInfo, 'isClosestToCursor' | 'seriesIdx' | 'datumIdx'> & {
   seriesIdx: number;
   datumIdx: number;
-  seriesName: string;
-  date: number;
-  x: number;
-  y: number;
-  formattedY: string;
-  markerColor: string;
-  metadata?: TimeSeriesMetadata;
-  isSelected: boolean;
   visualY: number;
   distance: number;
 };
-
-function getPixelXFromGrid(chart: EChartsInstance, xValue: number): number {
-  const pixelValue = chart.convertToPixel('grid', [xValue, 0]);
-  return pixelValue[0] ?? 0;
-}
 
 /**
  * Returns formatted series data for the points that are close to the user's cursor.
@@ -112,124 +107,123 @@ export function checkforNearbyTimeSeries(
 
   for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
     const currentSeries = seriesMapping[seriesIdx];
-    const currentMetadata = seriesMetadata?.[seriesIdx];
+    const hasCurrentSeries = currentSeries !== undefined;
 
-    if (!currentSeries) break;
+    if (hasCurrentSeries) {
+      const currentMetadata = seriesMetadata?.[seriesIdx];
+      const currentDataset = totalSeries > 0 ? data[seriesIdx] : undefined;
 
-    const currentDataset = totalSeries > 0 ? data[seriesIdx] : null;
-    if (!currentDataset) break;
+      if (currentDataset !== undefined && currentDataset !== null) {
+        const currentDatasetValues: TimeSeriesValueTuple[] = currentDataset.values;
+        const hasValidDatasetValues = currentDatasetValues !== undefined && Array.isArray(currentDatasetValues);
 
-    const currentDatasetValues: TimeSeriesValueTuple[] = currentDataset.values;
-    if (currentDatasetValues === undefined || !Array.isArray(currentDatasetValues)) break;
-    const lineSeries = currentSeries as LineSeriesOption;
-    const seriesType = currentSeries.type ?? 'line';
-    const currentSeriesName = lineSeries.name ? lineSeries.name.toString() : '';
-    const markerColor = lineSeries.color ?? '#000';
-    if (Array.isArray(data)) {
-      for (let datumIdx = 0; datumIdx < currentDatasetValues.length; datumIdx++) {
-        const nearbyTimeSeries = currentDatasetValues[datumIdx];
-        if (nearbyTimeSeries === undefined || !Array.isArray(nearbyTimeSeries)) break;
+        if (hasValidDatasetValues && Array.isArray(data)) {
+          const lineSeries = currentSeries as LineSeriesOption;
+          const seriesType = currentSeries.type ?? 'line';
+          const isBarSeries = seriesType === 'bar';
+          const isLineSeries = seriesType === 'line';
+          const currentSeriesName = lineSeries.name ? lineSeries.name.toString() : '';
+          const markerColor = lineSeries.color ?? '#000';
+          const stackId = lineSeries.stack;
+          const isStacked = stackId !== undefined;
 
-        const xValue = nearbyTimeSeries[0];
-        const yValue = nearbyTimeSeries[1];
+          for (let datumIdx = 0; datumIdx < currentDatasetValues.length; datumIdx++) {
+            const nearbyTimeSeries = currentDatasetValues[datumIdx];
+            const hasValidTimeSeries = nearbyTimeSeries !== undefined && Array.isArray(nearbyTimeSeries);
 
-        if (yValue !== undefined && yValue !== null) {
-          if (seriesType === 'bar') {
-            if (closestTimestamp === xValue && mousePixelX !== undefined) {
-              const stackId = lineSeries.stack;
-              const rawY = yValue;
-              let visualY: number;
-              if (stackId !== undefined) {
-                const currentStackTotal = stackTotals.get(stackId) ?? 0;
-                visualY = currentStackTotal + rawY;
-                stackTotals.set(stackId, visualY);
-              } else {
-                visualY = rawY;
-              }
-              const prevTimestamp = firstTimeSeriesValues?.[datumIdx - 1]?.[0];
-              const nextTimestamp = firstTimeSeriesValues?.[datumIdx + 1]?.[0];
-              const timestampCenterX = getPixelXFromGrid(chart, xValue);
-              let leftTimestampX: number | null = null;
-              let rightTimestampX: number | null = null;
-              if (prevTimestamp !== undefined) {
-                leftTimestampX = getPixelXFromGrid(chart, prevTimestamp);
-              }
-              if (nextTimestamp !== undefined) {
-                rightTimestampX = getPixelXFromGrid(chart, nextTimestamp);
-              }
-              let bandwidth = 20;
-              if (leftTimestampX !== null && rightTimestampX !== null) {
-                bandwidth = Math.min(
-                  Math.abs(timestampCenterX - leftTimestampX),
-                  Math.abs(rightTimestampX - timestampCenterX)
-                );
-              } else if (leftTimestampX !== null) {
-                bandwidth = Math.abs(timestampCenterX - leftTimestampX);
-              } else if (rightTimestampX !== null) {
-                bandwidth = Math.abs(rightTimestampX - timestampCenterX);
-              }
-              const groupLeft = timestampCenterX - bandwidth / 2;
-              const barsInGroup = barSeriesOrder.length || 1;
-              const idxInBars = Math.max(0, barSeriesOrder.indexOf(seriesIdx));
-              const segmentWidth = bandwidth / barsInGroup;
-              const segLeft = groupLeft + idxInBars * segmentWidth;
-              const segRight = segLeft + segmentWidth;
-              const base = stackId !== undefined ? visualY - rawY : 0;
-              const lower = Math.min(base, visualY);
-              const upper = Math.max(base, visualY);
-              const isHoveringXSegment = mousePixelX >= segLeft && mousePixelX <= segRight;
-              const isHoveringYBounds = stackId !== undefined ? cursorY >= lower && cursorY <= upper : true;
-              if (isHoveringXSegment && isHoveringYBounds) {
-                nearbySeriesIndexes.push(seriesIdx);
-                const isSelected = selectedSeriesIdx === seriesIdx;
-                const formattedY = formatValue(rawY, format);
-                const distance = Math.abs((segLeft + segRight) / 2 - mousePixelX);
-                candidates.push({
-                  seriesIdx,
-                  datumIdx,
-                  seriesName: currentSeriesName,
-                  date: closestTimestamp,
-                  x: xValue,
-                  y: rawY,
-                  formattedY,
-                  markerColor: markerColor.toString(),
-                  metadata: currentMetadata,
-                  isSelected,
-                  visualY,
-                  distance,
+            if (hasValidTimeSeries) {
+              const xValue = nearbyTimeSeries[0];
+              const yValue = nearbyTimeSeries[1];
+              const hasValidYValue = yValue !== undefined && yValue !== null;
+              const isAtClosestTimestamp = closestTimestamp === xValue;
+
+              if (hasValidYValue && isAtClosestTimestamp) {
+                const visualY = calculateVisualYForSeries({
+                  rawY: yValue,
+                  stackId,
+                  stackTotals,
                 });
-              }
-            }
-          } else {
-            if (closestTimestamp === xValue) {
-              const stackId = lineSeries.stack;
-              let visualY: number;
-              if (stackId !== undefined) {
-                const currentStackTotal = stackTotals.get(stackId) ?? 0;
-                visualY = currentStackTotal + yValue;
-                stackTotals.set(stackId, visualY);
-              } else {
-                visualY = yValue;
-              }
-              const distance = Math.abs(visualY - cursorY);
-              if (distance <= yBuffer) {
-                nearbySeriesIndexes.push(seriesIdx);
-                const isSelected = selectedSeriesIdx === seriesIdx;
-                const formattedY = formatValue(yValue, format);
-                candidates.push({
-                  seriesIdx,
-                  datumIdx,
-                  seriesName: currentSeriesName,
-                  date: closestTimestamp,
-                  x: xValue,
-                  y: yValue,
-                  formattedY,
-                  markerColor: markerColor.toString(),
-                  metadata: currentMetadata,
-                  isSelected,
-                  visualY,
-                  distance,
-                });
+
+                if (isBarSeries) {
+                  const hasValidMousePixelX = mousePixelX !== undefined;
+
+                  if (hasValidMousePixelX) {
+                    const prevTimestamp = firstTimeSeriesValues?.[datumIdx - 1]?.[0];
+                    const nextTimestamp = firstTimeSeriesValues?.[datumIdx + 1]?.[0];
+                    const timestampCenterX = getPixelXFromGrid(chart, xValue);
+
+                    const bandwidth = calculateBarBandwidth({
+                      timestampCenterX,
+                      prevTimestamp,
+                      nextTimestamp,
+                      chart,
+                    });
+
+                    const { segLeft, segRight } = calculateBarSegmentBounds({
+                      timestampCenterX,
+                      bandwidth,
+                      seriesIdx,
+                      barSeriesOrder,
+                    });
+
+                    const { lower, upper } = calculateBarYBounds({
+                      visualY,
+                      rawY: yValue,
+                      isStacked,
+                    });
+
+                    const isHoveringXSegment = mousePixelX >= segLeft && mousePixelX <= segRight;
+                    const isHoveringYBounds = isStacked ? cursorY >= lower && cursorY <= upper : true;
+                    const isHoveringBar = isHoveringXSegment && isHoveringYBounds;
+
+                    if (isHoveringBar) {
+                      const segmentCenterX = (segLeft + segRight) / 2;
+                      const distance = Math.abs(segmentCenterX - mousePixelX);
+                      const isSelected = selectedSeriesIdx === seriesIdx;
+                      const formattedY = formatValue(yValue, format);
+
+                      nearbySeriesIndexes.push(seriesIdx);
+                      candidates.push({
+                        seriesIdx,
+                        datumIdx,
+                        seriesName: currentSeriesName,
+                        date: closestTimestamp,
+                        x: xValue,
+                        y: yValue,
+                        formattedY,
+                        markerColor: markerColor.toString(),
+                        metadata: currentMetadata,
+                        isSelected,
+                        visualY,
+                        distance,
+                      });
+                    }
+                  }
+                } else if (isLineSeries) {
+                  const distance = Math.abs(visualY - cursorY);
+                  const isWithinYBuffer = distance <= yBuffer;
+
+                  if (isWithinYBuffer) {
+                    const isSelected = selectedSeriesIdx === seriesIdx;
+                    const formattedY = formatValue(yValue, format);
+
+                    nearbySeriesIndexes.push(seriesIdx);
+                    candidates.push({
+                      seriesIdx,
+                      datumIdx,
+                      seriesName: currentSeriesName,
+                      date: closestTimestamp,
+                      x: xValue,
+                      y: yValue,
+                      formattedY,
+                      markerColor: markerColor.toString(),
+                      metadata: currentMetadata,
+                      isSelected,
+                      visualY,
+                      distance,
+                    });
+                  }
+                }
               }
             }
           }
@@ -238,7 +232,8 @@ export function checkforNearbyTimeSeries(
     }
   }
 
-  if (candidates.length === 0) {
+  const hasNoCandidates = candidates.length === 0;
+  if (hasNoCandidates) {
     batchDispatchNearbySeriesActions(
       chart,
       nearbySeriesIndexes,
@@ -250,24 +245,36 @@ export function checkforNearbyTimeSeries(
     return currentNearbySeriesData;
   }
 
-  let winnerIdx = 0;
-  let minDistance = candidates[0]!.distance;
-  for (let i = 1; i < candidates.length; i++) {
-    const distance = candidates[i]!.distance;
-    if (distance < minDistance) {
-      minDistance = distance;
-      winnerIdx = i;
+  const findClosestCandidate = (): Candidate => {
+    let winnerIdx = 0;
+    let minDistance = candidates[0]!.distance;
+
+    for (let i = 1; i < candidates.length; i++) {
+      const candidateDistance = candidates[i]!.distance;
+      const isCloserThanCurrentWinner = candidateDistance < minDistance;
+
+      if (isCloserThanCurrentWinner) {
+        minDistance = candidateDistance;
+        winnerIdx = i;
+      }
     }
-  }
-  const winner = candidates[winnerIdx]!;
+
+    return candidates[winnerIdx]!;
+  };
+
+  const winner = findClosestCandidate();
 
   for (const candidate of candidates) {
     const isClosestToCursor = candidate === winner;
+
     if (isClosestToCursor) {
       emphasizedSeriesIndexes.push(candidate.seriesIdx);
+
       const duplicateValuesCount = yValueCounts.get(candidate.visualY) ?? 0;
+      const hasDuplicateValues = duplicateValuesCount > 0;
       yValueCounts.set(candidate.visualY, duplicateValuesCount + 1);
-      if (duplicateValuesCount > 0) {
+
+      if (hasDuplicateValues) {
         duplicateDatapoints.push({
           seriesIndex: candidate.seriesIdx,
           dataIndex: candidate.datumIdx,
@@ -275,6 +282,7 @@ export function checkforNearbyTimeSeries(
           yValue: candidate.visualY,
         });
       }
+
       emphasizedDatapoints.push({
         seriesIndex: candidate.seriesIdx,
         dataIndex: candidate.datumIdx,
@@ -284,6 +292,7 @@ export function checkforNearbyTimeSeries(
     } else {
       nonEmphasizedSeriesIndexes.push(candidate.seriesIdx);
     }
+
     currentNearbySeriesData.push({
       seriesIdx: candidate.seriesIdx,
       datumIdx: candidate.datumIdx,

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -18,9 +18,11 @@ import { EChartsDataFormat, OPTIMIZED_MODE_SERIES_LIMIT, TimeChartSeriesMapping,
 import { batchDispatchNearbySeriesActions, getPointInGrid, getClosestTimestamp } from '../utils';
 import { CursorCoordinates, CursorData, EMPTY_TOOLTIP_DATA } from './tooltip-model';
 
+// LOGZ.IO CHANGE START:: Tooltip is not behaving correctly [APPZ-1418]
+
 // increase multipliers to show more series in tooltip
-export const INCREASE_NEARBY_SERIES_MULTIPLIER = 5.5; // adjusts how many series show in tooltip (higher == more series shown)
-export const DYNAMIC_NEARBY_SERIES_MULTIPLIER = 30; // used for adjustment after series number divisor
+export const INCREASE_NEARBY_SERIES_MULTIPLIER = 1; // adjusts how many series show in tooltip (higher == more series shown)
+export const DYNAMIC_NEARBY_SERIES_MULTIPLIER = 10; // used for adjustment after series number divisor
 export const SHOW_FEWER_SERIES_LIMIT = 5;
 
 export interface NearbySeriesInfo {
@@ -33,13 +35,30 @@ export interface NearbySeriesInfo {
   y: number;
   formattedY: string;
   isClosestToCursor: boolean;
-  // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
   isSelected: boolean;
   metadata?: TimeSeriesMetadata;
-  // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
 }
 
 export type NearbySeriesArray = NearbySeriesInfo[];
+type Candidate = {
+  seriesIdx: number;
+  datumIdx: number;
+  seriesName: string;
+  date: number;
+  x: number;
+  y: number;
+  formattedY: string;
+  markerColor: string;
+  metadata?: TimeSeriesMetadata;
+  isSelected: boolean;
+  visualY: number;
+  distance: number;
+};
+
+function getPixelXFromGrid(chart: EChartsInstance, xValue: number): number {
+  const pixelValue = chart.convertToPixel('grid', [xValue, 0]);
+  return pixelValue[0] ?? 0;
+}
 
 /**
  * Returns formatted series data for the points that are close to the user's cursor.
@@ -51,11 +70,10 @@ export function checkforNearbyTimeSeries(
   pointInGrid: number[],
   yBuffer: number,
   chart: EChartsInstance,
-  // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
+  mousePixelX?: number,
   seriesMetadata?: TimeSeriesMetadata[],
   format?: FormatOptions,
   selectedSeriesIdx?: number | null
-  // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
 ): NearbySeriesArray {
   const currentNearbySeriesData: NearbySeriesArray = [];
   const cursorX: number | null = pointInGrid[0] ?? null;
@@ -75,6 +93,8 @@ export function checkforNearbyTimeSeries(
   const totalSeries = data.length;
 
   const yValueCounts: Map<number, number> = new Map();
+  const stackTotals: Map<string, number> = new Map();
+  const candidates: Candidate[] = [];
 
   // Only need to loop through first dataset source since getCommonTimeScale ensures xAxis timestamps are consistent
   const firstTimeSeriesValues = data[0]?.values;
@@ -84,10 +104,15 @@ export function checkforNearbyTimeSeries(
     return EMPTY_TOOLTIP_DATA;
   }
 
-  // find the timestamp with data that is closest to cursorX
+  const barSeriesOrder: number[] = seriesMapping.reduce((acc: number[], series, idx) => {
+    const seriesType = (series as { type?: string }).type;
+    if (seriesType === 'bar') acc.push(idx);
+    return acc;
+  }, []);
+
   for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
     const currentSeries = seriesMapping[seriesIdx];
-    const currentMetadata = seriesMetadata?.[seriesIdx]; // LOGZ.IO CHANGE:: Drilldown panel [APPZ-377]
+    const currentMetadata = seriesMetadata?.[seriesIdx];
 
     if (!currentSeries) break;
 
@@ -97,6 +122,7 @@ export function checkforNearbyTimeSeries(
     const currentDatasetValues: TimeSeriesValueTuple[] = currentDataset.values;
     if (currentDatasetValues === undefined || !Array.isArray(currentDatasetValues)) break;
     const lineSeries = currentSeries as LineSeriesOption;
+    const seriesType = currentSeries.type ?? 'line';
     const currentSeriesName = lineSeries.name ? lineSeries.name.toString() : '';
     const markerColor = lineSeries.color ?? '#000';
     if (Array.isArray(data)) {
@@ -107,94 +133,173 @@ export function checkforNearbyTimeSeries(
         const xValue = nearbyTimeSeries[0];
         const yValue = nearbyTimeSeries[1];
 
-        // TODO: ensure null values not displayed in tooltip
         if (yValue !== undefined && yValue !== null) {
-          if (closestTimestamp === xValue) {
-            const stackId = (lineSeries as { stack?: string }).stack;
-            let visualY = yValue as number;
-            if (stackId !== undefined) {
-              let cumulativeY = 0;
-              for (let sIdx = 0; sIdx <= seriesIdx; sIdx++) {
-                const stackedSeries = seriesMapping[sIdx] as LineSeriesOption | undefined;
-                if (!stackedSeries) continue;
-                const stackedStackId = (stackedSeries as { stack?: string }).stack;
-                if (stackedStackId !== stackId) continue;
-                const stackedDataset = data[sIdx]?.values;
-                if (!Array.isArray(stackedDataset)) continue;
-                const tuple = stackedDataset.find((t) => Array.isArray(t) && t[0] === closestTimestamp);
-                const v = tuple ? (tuple[1] as number | null) : null;
-                if (typeof v === 'number') {
-                  cumulativeY += v;
-                }
-              }
-              visualY = cumulativeY;
-            }
-
-            if (cursorY <= visualY + yBuffer && cursorY >= visualY - yBuffer) {
-              // show fewer bold series in tooltip when many total series
-              const minPercentRange = totalSeries > SHOW_FEWER_SERIES_LIMIT ? 2 : 5;
-              const percentRangeToCheck = Math.max(minPercentRange, 100 / totalSeries);
-              const isClosestToCursor = isWithinPercentageRange({
-                valueToCheck: cursorY,
-                baseValue: visualY,
-                percentage: percentRangeToCheck,
-              });
-              const isSelected = selectedSeriesIdx === seriesIdx; // LOGZ.IO CHANGE:: Drilldown panel [APPZ-377]
-              if (isClosestToCursor) {
-                // shows as bold in tooltip, customize 'emphasis' options in getTimeSeries util
-                emphasizedSeriesIndexes.push(seriesIdx);
-
-                // Used to determine which datapoint to apply select styles to.
-                // Accounts for cases where lines may be rendered directly on top of eachother.
-                const duplicateValuesCount = yValueCounts.get(visualY) ?? 0;
-                yValueCounts.set(visualY, duplicateValuesCount + 1);
-                if (duplicateValuesCount > 0) {
-                  duplicateDatapoints.push({
-                    seriesIndex: seriesIdx,
-                    dataIndex: datumIdx,
-                    seriesName: currentSeriesName,
-                    yValue: visualY,
-                  });
-                }
-
-                // keep track of all bold datapoints in tooltip so that 'select' state only applied to topmost
-                emphasizedDatapoints.push({
-                  seriesIndex: seriesIdx,
-                  dataIndex: datumIdx,
-                  seriesName: currentSeriesName,
-                  yValue: visualY,
-                });
+          if (seriesType === 'bar') {
+            if (closestTimestamp === xValue && mousePixelX !== undefined) {
+              const stackId = lineSeries.stack;
+              const rawY = yValue;
+              let visualY: number;
+              if (stackId !== undefined) {
+                const currentStackTotal = stackTotals.get(stackId) ?? 0;
+                visualY = currentStackTotal + rawY;
+                stackTotals.set(stackId, visualY);
               } else {
-                nonEmphasizedSeriesIndexes.push(seriesIdx);
-                // ensure series far away from cursor are not highlighted
-                chart.dispatchAction({
-                  type: 'downplay',
-                  seriesIndex: seriesIdx,
+                visualY = rawY;
+              }
+              const prevTimestamp = firstTimeSeriesValues?.[datumIdx - 1]?.[0];
+              const nextTimestamp = firstTimeSeriesValues?.[datumIdx + 1]?.[0];
+              const timestampCenterX = getPixelXFromGrid(chart, xValue);
+              let leftTimestampX: number | null = null;
+              let rightTimestampX: number | null = null;
+              if (prevTimestamp !== undefined) {
+                leftTimestampX = getPixelXFromGrid(chart, prevTimestamp);
+              }
+              if (nextTimestamp !== undefined) {
+                rightTimestampX = getPixelXFromGrid(chart, nextTimestamp);
+              }
+              let bandwidth = 20;
+              if (leftTimestampX !== null && rightTimestampX !== null) {
+                bandwidth = Math.min(
+                  Math.abs(timestampCenterX - leftTimestampX),
+                  Math.abs(rightTimestampX - timestampCenterX)
+                );
+              } else if (leftTimestampX !== null) {
+                bandwidth = Math.abs(timestampCenterX - leftTimestampX);
+              } else if (rightTimestampX !== null) {
+                bandwidth = Math.abs(rightTimestampX - timestampCenterX);
+              }
+              const groupLeft = timestampCenterX - bandwidth / 2;
+              const barsInGroup = barSeriesOrder.length || 1;
+              const idxInBars = Math.max(0, barSeriesOrder.indexOf(seriesIdx));
+              const segmentWidth = bandwidth / barsInGroup;
+              const segLeft = groupLeft + idxInBars * segmentWidth;
+              const segRight = segLeft + segmentWidth;
+              const base = stackId !== undefined ? visualY - rawY : 0;
+              const lower = Math.min(base, visualY);
+              const upper = Math.max(base, visualY);
+              const isHoveringXSegment = mousePixelX >= segLeft && mousePixelX <= segRight;
+              const isHoveringYBounds = stackId !== undefined ? cursorY >= lower && cursorY <= upper : true;
+              if (isHoveringXSegment && isHoveringYBounds) {
+                nearbySeriesIndexes.push(seriesIdx);
+                const isSelected = selectedSeriesIdx === seriesIdx;
+                const formattedY = formatValue(rawY, format);
+                const distance = Math.abs((segLeft + segRight) / 2 - mousePixelX);
+                candidates.push({
+                  seriesIdx,
+                  datumIdx,
+                  seriesName: currentSeriesName,
+                  date: closestTimestamp,
+                  x: xValue,
+                  y: rawY,
+                  formattedY,
+                  markerColor: markerColor.toString(),
+                  metadata: currentMetadata,
+                  isSelected,
+                  visualY,
+                  distance,
                 });
               }
-              const formattedY = formatValue(yValue, format);
-              currentNearbySeriesData.push({
-                seriesIdx: seriesIdx,
-                datumIdx: datumIdx,
-                seriesName: currentSeriesName,
-                date: closestTimestamp,
-                x: xValue,
-                y: yValue,
-                formattedY: formattedY,
-                markerColor: markerColor.toString(),
-                isClosestToCursor,
-                // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
-                metadata: currentMetadata,
-                isSelected,
-                // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
-              });
-              nearbySeriesIndexes.push(seriesIdx);
+            }
+          } else {
+            if (closestTimestamp === xValue) {
+              const stackId = lineSeries.stack;
+              let visualY: number;
+              if (stackId !== undefined) {
+                const currentStackTotal = stackTotals.get(stackId) ?? 0;
+                visualY = currentStackTotal + yValue;
+                stackTotals.set(stackId, visualY);
+              } else {
+                visualY = yValue;
+              }
+              const distance = Math.abs(visualY - cursorY);
+              if (distance <= yBuffer) {
+                nearbySeriesIndexes.push(seriesIdx);
+                const isSelected = selectedSeriesIdx === seriesIdx;
+                const formattedY = formatValue(yValue, format);
+                candidates.push({
+                  seriesIdx,
+                  datumIdx,
+                  seriesName: currentSeriesName,
+                  date: closestTimestamp,
+                  x: xValue,
+                  y: yValue,
+                  formattedY,
+                  markerColor: markerColor.toString(),
+                  metadata: currentMetadata,
+                  isSelected,
+                  visualY,
+                  distance,
+                });
+              }
             }
           }
         }
       }
     }
   }
+
+  if (candidates.length === 0) {
+    batchDispatchNearbySeriesActions(
+      chart,
+      nearbySeriesIndexes,
+      emphasizedSeriesIndexes,
+      nonEmphasizedSeriesIndexes,
+      emphasizedDatapoints,
+      duplicateDatapoints
+    );
+    return currentNearbySeriesData;
+  }
+
+  let winnerIdx = 0;
+  let minDistance = candidates[0]!.distance;
+  for (let i = 1; i < candidates.length; i++) {
+    const distance = candidates[i]!.distance;
+    if (distance < minDistance) {
+      minDistance = distance;
+      winnerIdx = i;
+    }
+  }
+  const winner = candidates[winnerIdx]!;
+
+  for (const candidate of candidates) {
+    const isClosestToCursor = candidate === winner;
+    if (isClosestToCursor) {
+      emphasizedSeriesIndexes.push(candidate.seriesIdx);
+      const duplicateValuesCount = yValueCounts.get(candidate.visualY) ?? 0;
+      yValueCounts.set(candidate.visualY, duplicateValuesCount + 1);
+      if (duplicateValuesCount > 0) {
+        duplicateDatapoints.push({
+          seriesIndex: candidate.seriesIdx,
+          dataIndex: candidate.datumIdx,
+          seriesName: candidate.seriesName,
+          yValue: candidate.visualY,
+        });
+      }
+      emphasizedDatapoints.push({
+        seriesIndex: candidate.seriesIdx,
+        dataIndex: candidate.datumIdx,
+        seriesName: candidate.seriesName,
+        yValue: candidate.visualY,
+      });
+    } else {
+      nonEmphasizedSeriesIndexes.push(candidate.seriesIdx);
+    }
+    currentNearbySeriesData.push({
+      seriesIdx: candidate.seriesIdx,
+      datumIdx: candidate.datumIdx,
+      seriesName: candidate.seriesName,
+      date: candidate.date,
+      x: candidate.x,
+      y: candidate.y,
+      formattedY: candidate.formattedY,
+      markerColor: candidate.markerColor,
+      isClosestToCursor,
+      metadata: candidate.metadata,
+      isSelected: candidate.isSelected,
+    });
+  }
+
+  // LOGZ.IO CHANGE END:: Tooltip is not behaving correctly [APPZ-1418]
 
   batchDispatchNearbySeriesActions(
     chart,
@@ -390,6 +495,7 @@ export function getNearbySeriesData({
       yBuffer,
       chart,
       // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
+      mousePos.plotCanvas.x,
       seriesMetadata,
       format,
       selectedSeriesIdx

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -12,18 +12,12 @@
 // limitations under the License.
 
 import { ECharts as EChartsInstance } from 'echarts/core';
-import { LineSeriesOption } from 'echarts/charts';
-import { formatValue, TimeSeriesValueTuple, FormatOptions, TimeSeries, TimeSeriesMetadata } from '@perses-dev/core';
-import { EChartsDataFormat, OPTIMIZED_MODE_SERIES_LIMIT, TimeChartSeriesMapping, DatapointInfo } from '../model';
+import { formatValue, FormatOptions, TimeSeries, TimeSeriesMetadata } from '@perses-dev/core';
+import { EChartsDataFormat, OPTIMIZED_MODE_SERIES_LIMIT, TimeChartSeriesMapping } from '../model';
 import { batchDispatchNearbySeriesActions, getPointInGrid, getClosestTimestamp } from '../utils';
 import { CursorCoordinates, CursorData, EMPTY_TOOLTIP_DATA } from './tooltip-model';
-import {
-  calculateBarBandwidth,
-  calculateBarSegmentBounds,
-  calculateBarYBounds,
-  calculateVisualYForSeries,
-  getPixelXFromGrid,
-} from './utils';
+import { gatherCandidates, findClosestCandidate, processCandidates } from './utils';
+import { NearbySeriesArray } from './types';
 
 // LOGZ.IO CHANGE START:: Tooltip is not behaving correctly [APPZ-1418]
 
@@ -31,29 +25,6 @@ import {
 export const INCREASE_NEARBY_SERIES_MULTIPLIER = 1; // adjusts how many series show in tooltip (higher == more series shown)
 export const DYNAMIC_NEARBY_SERIES_MULTIPLIER = 10; // used for adjustment after series number divisor
 export const SHOW_FEWER_SERIES_LIMIT = 5;
-
-export interface NearbySeriesInfo {
-  seriesIdx: number | null;
-  datumIdx: number | null;
-  seriesName: string;
-  date: number;
-  markerColor: string;
-  x: number;
-  y: number;
-  formattedY: string;
-  isClosestToCursor: boolean;
-  isSelected: boolean;
-  metadata?: TimeSeriesMetadata;
-}
-
-export type NearbySeriesArray = NearbySeriesInfo[];
-
-type Candidate = Omit<NearbySeriesInfo, 'isClosestToCursor' | 'seriesIdx' | 'datumIdx'> & {
-  seriesIdx: number;
-  datumIdx: number;
-  visualY: number;
-  distance: number;
-};
 
 /**
  * Returns formatted series data for the points that are close to the user's cursor.
@@ -70,26 +41,14 @@ export function checkforNearbyTimeSeries(
   format?: FormatOptions,
   selectedSeriesIdx?: number | null
 ): NearbySeriesArray {
-  const currentNearbySeriesData: NearbySeriesArray = [];
   const cursorX: number | null = pointInGrid[0] ?? null;
   const cursorY: number | null = pointInGrid[1] ?? null;
 
-  if (cursorX === null || cursorY === null) return currentNearbySeriesData;
+  if (cursorX === null || cursorY === null) return EMPTY_TOOLTIP_DATA;
 
-  if (chart.dispatchAction === undefined) return currentNearbySeriesData;
+  if (chart.dispatchAction === undefined) return EMPTY_TOOLTIP_DATA;
 
-  if (!Array.isArray(data)) return currentNearbySeriesData;
-  const nearbySeriesIndexes: number[] = [];
-  const emphasizedSeriesIndexes: number[] = [];
-  const nonEmphasizedSeriesIndexes: number[] = [];
-  const emphasizedDatapoints: DatapointInfo[] = [];
-  const duplicateDatapoints: DatapointInfo[] = [];
-
-  const totalSeries = data.length;
-
-  const yValueCounts: Map<number, number> = new Map();
-  const stackTotals: Map<string, number> = new Map();
-  const candidates: Candidate[] = [];
+  if (!Array.isArray(data)) return EMPTY_TOOLTIP_DATA;
 
   // Only need to loop through first dataset source since getCommonTimeScale ensures xAxis timestamps are consistent
   const firstTimeSeriesValues = data[0]?.values;
@@ -99,214 +58,34 @@ export function checkforNearbyTimeSeries(
     return EMPTY_TOOLTIP_DATA;
   }
 
-  const barSeriesOrder: number[] = seriesMapping.reduce((acc: number[], series, idx) => {
-    const seriesType = (series as { type?: string }).type;
-    if (seriesType === 'bar') acc.push(idx);
-    return acc;
-  }, []);
+  const candidates = gatherCandidates({
+    data,
+    seriesMapping,
+    closestTimestamp,
+    cursorY,
+    yBuffer,
+    chart,
+    mousePixelX,
+    seriesMetadata,
+    format,
+    selectedSeriesIdx,
+  });
 
-  for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
-    const currentSeries = seriesMapping[seriesIdx];
-    const hasCurrentSeries = currentSeries !== undefined;
-
-    if (hasCurrentSeries) {
-      const currentMetadata = seriesMetadata?.[seriesIdx];
-      const currentDataset = totalSeries > 0 ? data[seriesIdx] : undefined;
-
-      if (currentDataset !== undefined && currentDataset !== null) {
-        const currentDatasetValues: TimeSeriesValueTuple[] = currentDataset.values;
-        const hasValidDatasetValues = currentDatasetValues !== undefined && Array.isArray(currentDatasetValues);
-
-        if (hasValidDatasetValues && Array.isArray(data)) {
-          const lineSeries = currentSeries as LineSeriesOption;
-          const seriesType = currentSeries.type ?? 'line';
-          const isBarSeries = seriesType === 'bar';
-          const isLineSeries = seriesType === 'line';
-          const currentSeriesName = lineSeries.name ? lineSeries.name.toString() : '';
-          const markerColor = lineSeries.color ?? '#000';
-          const stackId = lineSeries.stack;
-          const isStacked = stackId !== undefined;
-
-          for (let datumIdx = 0; datumIdx < currentDatasetValues.length; datumIdx++) {
-            const nearbyTimeSeries = currentDatasetValues[datumIdx];
-            const hasValidTimeSeries = nearbyTimeSeries !== undefined && Array.isArray(nearbyTimeSeries);
-
-            if (hasValidTimeSeries) {
-              const xValue = nearbyTimeSeries[0];
-              const yValue = nearbyTimeSeries[1];
-              const hasValidYValue = yValue !== undefined && yValue !== null;
-              const isAtClosestTimestamp = closestTimestamp === xValue;
-
-              if (hasValidYValue && isAtClosestTimestamp) {
-                const visualY = calculateVisualYForSeries({
-                  rawY: yValue,
-                  stackId,
-                  stackTotals,
-                });
-
-                if (isBarSeries) {
-                  const hasValidMousePixelX = mousePixelX !== undefined;
-
-                  if (hasValidMousePixelX) {
-                    const prevTimestamp = firstTimeSeriesValues?.[datumIdx - 1]?.[0];
-                    const nextTimestamp = firstTimeSeriesValues?.[datumIdx + 1]?.[0];
-                    const timestampCenterX = getPixelXFromGrid(chart, xValue);
-
-                    const bandwidth = calculateBarBandwidth({
-                      timestampCenterX,
-                      prevTimestamp,
-                      nextTimestamp,
-                      chart,
-                    });
-
-                    const { segLeft, segRight } = calculateBarSegmentBounds({
-                      timestampCenterX,
-                      bandwidth,
-                      seriesIdx,
-                      barSeriesOrder,
-                    });
-
-                    const { lower, upper } = calculateBarYBounds({
-                      visualY,
-                      rawY: yValue,
-                      isStacked,
-                    });
-
-                    const isHoveringXSegment = mousePixelX >= segLeft && mousePixelX <= segRight;
-                    const isHoveringYBounds = isStacked ? cursorY >= lower && cursorY <= upper : true;
-                    const isHoveringBar = isHoveringXSegment && isHoveringYBounds;
-
-                    if (isHoveringBar) {
-                      const segmentCenterX = (segLeft + segRight) / 2;
-                      const distance = Math.abs(segmentCenterX - mousePixelX);
-                      const isSelected = selectedSeriesIdx === seriesIdx;
-                      const formattedY = formatValue(yValue, format);
-
-                      nearbySeriesIndexes.push(seriesIdx);
-                      candidates.push({
-                        seriesIdx,
-                        datumIdx,
-                        seriesName: currentSeriesName,
-                        date: closestTimestamp,
-                        x: xValue,
-                        y: yValue,
-                        formattedY,
-                        markerColor: markerColor.toString(),
-                        metadata: currentMetadata,
-                        isSelected,
-                        visualY,
-                        distance,
-                      });
-                    }
-                  }
-                } else if (isLineSeries) {
-                  const distance = Math.abs(visualY - cursorY);
-                  const isWithinYBuffer = distance <= yBuffer;
-
-                  if (isWithinYBuffer) {
-                    const isSelected = selectedSeriesIdx === seriesIdx;
-                    const formattedY = formatValue(yValue, format);
-
-                    nearbySeriesIndexes.push(seriesIdx);
-                    candidates.push({
-                      seriesIdx,
-                      datumIdx,
-                      seriesName: currentSeriesName,
-                      date: closestTimestamp,
-                      x: xValue,
-                      y: yValue,
-                      formattedY,
-                      markerColor: markerColor.toString(),
-                      metadata: currentMetadata,
-                      isSelected,
-                      visualY,
-                      distance,
-                    });
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+  if (candidates.length === 0) {
+    batchDispatchNearbySeriesActions(chart, [], [], [], [], []);
+    return EMPTY_TOOLTIP_DATA;
   }
 
-  const hasNoCandidates = candidates.length === 0;
-  if (hasNoCandidates) {
-    batchDispatchNearbySeriesActions(
-      chart,
-      nearbySeriesIndexes,
-      emphasizedSeriesIndexes,
-      nonEmphasizedSeriesIndexes,
-      emphasizedDatapoints,
-      duplicateDatapoints
-    );
-    return currentNearbySeriesData;
-  }
+  const winner = findClosestCandidate(candidates);
 
-  const findClosestCandidate = (): Candidate => {
-    let winnerIdx = 0;
-    let minDistance = candidates[0]!.distance;
-
-    for (let i = 1; i < candidates.length; i++) {
-      const candidateDistance = candidates[i]!.distance;
-      const isCloserThanCurrentWinner = candidateDistance < minDistance;
-
-      if (isCloserThanCurrentWinner) {
-        minDistance = candidateDistance;
-        winnerIdx = i;
-      }
-    }
-
-    return candidates[winnerIdx]!;
-  };
-
-  const winner = findClosestCandidate();
-
-  for (const candidate of candidates) {
-    const isClosestToCursor = candidate === winner;
-
-    if (isClosestToCursor) {
-      emphasizedSeriesIndexes.push(candidate.seriesIdx);
-
-      const duplicateValuesCount = yValueCounts.get(candidate.visualY) ?? 0;
-      const hasDuplicateValues = duplicateValuesCount > 0;
-      yValueCounts.set(candidate.visualY, duplicateValuesCount + 1);
-
-      if (hasDuplicateValues) {
-        duplicateDatapoints.push({
-          seriesIndex: candidate.seriesIdx,
-          dataIndex: candidate.datumIdx,
-          seriesName: candidate.seriesName,
-          yValue: candidate.visualY,
-        });
-      }
-
-      emphasizedDatapoints.push({
-        seriesIndex: candidate.seriesIdx,
-        dataIndex: candidate.datumIdx,
-        seriesName: candidate.seriesName,
-        yValue: candidate.visualY,
-      });
-    } else {
-      nonEmphasizedSeriesIndexes.push(candidate.seriesIdx);
-    }
-
-    currentNearbySeriesData.push({
-      seriesIdx: candidate.seriesIdx,
-      datumIdx: candidate.datumIdx,
-      seriesName: candidate.seriesName,
-      date: candidate.date,
-      x: candidate.x,
-      y: candidate.y,
-      formattedY: candidate.formattedY,
-      markerColor: candidate.markerColor,
-      isClosestToCursor,
-      metadata: candidate.metadata,
-      isSelected: candidate.isSelected,
-    });
-  }
+  const {
+    currentNearbySeriesData,
+    emphasizedSeriesIndexes,
+    nonEmphasizedSeriesIndexes,
+    emphasizedDatapoints,
+    duplicateDatapoints,
+    nearbySeriesIndexes,
+  } = processCandidates(candidates, winner);
 
   // LOGZ.IO CHANGE END:: Tooltip is not behaving correctly [APPZ-1418]
 

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -110,13 +110,33 @@ export function checkforNearbyTimeSeries(
         // TODO: ensure null values not displayed in tooltip
         if (yValue !== undefined && yValue !== null) {
           if (closestTimestamp === xValue) {
-            if (cursorY <= yValue + yBuffer && cursorY >= yValue - yBuffer) {
+            const stackId = (lineSeries as { stack?: string }).stack;
+            let visualY = yValue as number;
+            if (stackId !== undefined) {
+              let cumulativeY = 0;
+              for (let sIdx = 0; sIdx <= seriesIdx; sIdx++) {
+                const stackedSeries = seriesMapping[sIdx] as LineSeriesOption | undefined;
+                if (!stackedSeries) continue;
+                const stackedStackId = (stackedSeries as { stack?: string }).stack;
+                if (stackedStackId !== stackId) continue;
+                const stackedDataset = data[sIdx]?.values;
+                if (!Array.isArray(stackedDataset)) continue;
+                const tuple = stackedDataset.find((t) => Array.isArray(t) && t[0] === closestTimestamp);
+                const v = tuple ? (tuple[1] as number | null) : null;
+                if (typeof v === 'number') {
+                  cumulativeY += v;
+                }
+              }
+              visualY = cumulativeY;
+            }
+
+            if (cursorY <= visualY + yBuffer && cursorY >= visualY - yBuffer) {
               // show fewer bold series in tooltip when many total series
               const minPercentRange = totalSeries > SHOW_FEWER_SERIES_LIMIT ? 2 : 5;
               const percentRangeToCheck = Math.max(minPercentRange, 100 / totalSeries);
               const isClosestToCursor = isWithinPercentageRange({
                 valueToCheck: cursorY,
-                baseValue: yValue,
+                baseValue: visualY,
                 percentage: percentRangeToCheck,
               });
               const isSelected = selectedSeriesIdx === seriesIdx; // LOGZ.IO CHANGE:: Drilldown panel [APPZ-377]
@@ -126,14 +146,14 @@ export function checkforNearbyTimeSeries(
 
                 // Used to determine which datapoint to apply select styles to.
                 // Accounts for cases where lines may be rendered directly on top of eachother.
-                const duplicateValuesCount = yValueCounts.get(yValue) ?? 0;
-                yValueCounts.set(yValue, duplicateValuesCount + 1);
+                const duplicateValuesCount = yValueCounts.get(visualY) ?? 0;
+                yValueCounts.set(visualY, duplicateValuesCount + 1);
                 if (duplicateValuesCount > 0) {
                   duplicateDatapoints.push({
                     seriesIndex: seriesIdx,
                     dataIndex: datumIdx,
                     seriesName: currentSeriesName,
-                    yValue: yValue,
+                    yValue: visualY,
                   });
                 }
 
@@ -142,7 +162,7 @@ export function checkforNearbyTimeSeries(
                   seriesIndex: seriesIdx,
                   dataIndex: datumIdx,
                   seriesName: currentSeriesName,
-                  yValue: yValue,
+                  yValue: visualY,
                 });
               } else {
                 nonEmphasizedSeriesIndexes.push(seriesIdx);

--- a/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
+++ b/ui/components/src/TimeSeriesTooltip/tooltip-model.ts
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { useEffect, useState } from 'react';
-import { NearbySeriesArray, NearbySeriesInfo } from './nearby-series';
+import { NearbySeriesArray, NearbySeriesInfo } from './types';
 
 export const TOOLTIP_MIN_WIDTH = 375;
 export const TOOLTIP_MAX_WIDTH = 650;

--- a/ui/components/src/TimeSeriesTooltip/types.ts
+++ b/ui/components/src/TimeSeriesTooltip/types.ts
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { ECharts as EChartsInstance } from 'echarts/core';
 import { TimeSeriesMetadata } from '@perses-dev/core';
 

--- a/ui/components/src/TimeSeriesTooltip/types.ts
+++ b/ui/components/src/TimeSeriesTooltip/types.ts
@@ -22,6 +22,7 @@ export type Candidate = Omit<NearbySeriesInfo, 'isClosestToCursor' | 'seriesIdx'
   datumIdx: number;
   visualY: number;
   distance: number;
+  isSelected: boolean;
 };
 
 export type CalculateVisualYForSeriesParams = {
@@ -60,4 +61,22 @@ export type BarYBounds = {
   base: number;
   lower: number;
   upper: number;
+};
+
+/**
+ * Parameters for isWithinPercentageRange function
+ */
+export type IsWithinPercentageRangeParams = {
+  valueToCheck: number;
+  baseValue: number;
+  percentage: number;
+};
+
+/**
+ * Parameters for getYBuffer function
+ */
+export type GetYBufferParams = {
+  yInterval: number;
+  totalSeries: number;
+  showAllSeries?: boolean;
 };

--- a/ui/components/src/TimeSeriesTooltip/types.ts
+++ b/ui/components/src/TimeSeriesTooltip/types.ts
@@ -1,0 +1,63 @@
+import { ECharts as EChartsInstance } from 'echarts/core';
+import { TimeSeriesMetadata } from '@perses-dev/core';
+
+export interface NearbySeriesInfo {
+  seriesIdx: number | null;
+  datumIdx: number | null;
+  seriesName: string;
+  date: number;
+  markerColor: string;
+  x: number;
+  y: number;
+  formattedY: string;
+  isClosestToCursor: boolean;
+  isSelected: boolean;
+  metadata?: TimeSeriesMetadata;
+}
+
+export type NearbySeriesArray = NearbySeriesInfo[];
+
+export type Candidate = Omit<NearbySeriesInfo, 'isClosestToCursor' | 'seriesIdx' | 'datumIdx'> & {
+  seriesIdx: number;
+  datumIdx: number;
+  visualY: number;
+  distance: number;
+};
+
+export type CalculateVisualYForSeriesParams = {
+  rawY: number;
+  stackId?: string;
+  stackTotals: Map<string, number>;
+};
+
+export type CalculateBarBandwidthParams = {
+  timestampCenterX: number;
+  prevTimestamp: number | undefined;
+  nextTimestamp: number | undefined;
+  chart: EChartsInstance;
+  defaultBandwidth?: number;
+};
+
+export type CalculateBarSegmentBoundsParams = {
+  timestampCenterX: number;
+  bandwidth: number;
+  seriesIdx: number;
+  barSeriesOrder: number[];
+};
+
+export type BarSegmentBounds = {
+  segLeft: number;
+  segRight: number;
+};
+
+export type CalculateBarYBoundsParams = {
+  visualY: number;
+  rawY: number;
+  isStacked: boolean;
+};
+
+export type BarYBounds = {
+  base: number;
+  lower: number;
+  upper: number;
+};

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -13,6 +13,9 @@
 
 import { ECharts as EChartsInstance } from 'echarts/core';
 import { Theme } from '@mui/material';
+import { formatValue, TimeSeries, TimeSeriesMetadata, FormatOptions, TimeSeriesValueTuple } from '@perses-dev/core';
+import { LineSeriesOption } from 'echarts/charts';
+import { DatapointInfo, TimeChartSeriesMapping } from '../model';
 import {
   CursorCoordinates,
   CursorData,
@@ -22,6 +25,16 @@ import {
   TOOLTIP_BG_COLOR_FALLBACK,
   TOOLTIP_PADDING,
 } from './tooltip-model';
+import {
+  CalculateBarBandwidthParams,
+  CalculateBarSegmentBoundsParams,
+  CalculateBarYBoundsParams,
+  CalculateVisualYForSeriesParams,
+  BarSegmentBounds,
+  BarYBounds,
+  Candidate,
+  NearbySeriesArray,
+} from './types';
 
 /**
  * Determine position of tooltip depending on chart dimensions and the number of focused series
@@ -131,15 +144,7 @@ export function getPixelXFromGrid(chart: EChartsInstance, xValue: number): numbe
   return pixelValue[0] ?? 0;
 }
 
-export function calculateVisualYForSeries({
-  rawY,
-  stackId,
-  stackTotals,
-}: {
-  rawY: number;
-  stackId?: string;
-  stackTotals: Map<string, number>;
-}): number {
+export function calculateVisualYForSeries({ rawY, stackId, stackTotals }: CalculateVisualYForSeriesParams): number {
   if (stackId === undefined) {
     return rawY;
   }
@@ -157,13 +162,7 @@ export function calculateBarBandwidth({
   nextTimestamp,
   chart,
   defaultBandwidth = 20,
-}: {
-  timestampCenterX: number;
-  prevTimestamp: number | undefined;
-  nextTimestamp: number | undefined;
-  chart: EChartsInstance;
-  defaultBandwidth?: number;
-}): number {
+}: CalculateBarBandwidthParams): number {
   const hasLeftNeighbor = prevTimestamp !== undefined;
   const hasRightNeighbor = nextTimestamp !== undefined;
 
@@ -204,12 +203,7 @@ export function calculateBarSegmentBounds({
   bandwidth,
   seriesIdx,
   barSeriesOrder,
-}: {
-  timestampCenterX: number;
-  bandwidth: number;
-  seriesIdx: number;
-  barSeriesOrder: number[];
-}): { segLeft: number; segRight: number } {
+}: CalculateBarSegmentBoundsParams): BarSegmentBounds {
   const groupLeft = timestampCenterX - bandwidth / 2;
   const barsInGroup = barSeriesOrder.length || 1;
   const idxInBars = Math.max(0, barSeriesOrder.indexOf(seriesIdx));
@@ -220,23 +214,275 @@ export function calculateBarSegmentBounds({
   return { segLeft, segRight };
 }
 
-export function calculateBarYBounds({
-  visualY,
-  rawY,
-  isStacked,
-}: {
-  visualY: number;
-  rawY: number;
-  isStacked: boolean;
-}): {
-  base: number;
-  lower: number;
-  upper: number;
-} {
+export function calculateBarYBounds({ visualY, rawY, isStacked }: CalculateBarYBoundsParams): BarYBounds {
   const base = isStacked ? visualY - rawY : 0;
   const lower = Math.min(base, visualY);
   const upper = Math.max(base, visualY);
 
   return { base, lower, upper };
 }
+
+export function findClosestCandidate(candidates: Candidate[]): Candidate {
+  if (candidates.length === 0) {
+    throw new Error('Cannot find closest candidate in an empty array.');
+  }
+
+  let winnerIdx = 0;
+  let minDistance = candidates[0]!.distance;
+
+  for (let i = 1; i < candidates.length; i++) {
+    const candidateDistance = candidates[i]!.distance;
+    const isCloserThanCurrentWinner = candidateDistance < minDistance;
+
+    if (isCloserThanCurrentWinner) {
+      minDistance = candidateDistance;
+      winnerIdx = i;
+    }
+  }
+
+  return candidates[winnerIdx]!;
+}
+
+/**
+ * Gathers all series points that are close to the user's cursor.
+ */
+export function gatherCandidates({
+  data,
+  seriesMapping,
+  closestTimestamp,
+  cursorY,
+  yBuffer,
+  chart,
+  mousePixelX,
+  seriesMetadata,
+  format,
+  selectedSeriesIdx,
+}: {
+  data: TimeSeries[];
+  seriesMapping: TimeChartSeriesMapping;
+  closestTimestamp: number;
+  cursorY: number;
+  yBuffer: number;
+  chart: EChartsInstance;
+  mousePixelX?: number;
+  seriesMetadata?: TimeSeriesMetadata[];
+  format?: FormatOptions;
+  selectedSeriesIdx?: number | null;
+}): Candidate[] {
+  const candidates: Candidate[] = [];
+  const totalSeries = data.length;
+  const stackTotals: Map<string, number> = new Map();
+
+  const barSeriesOrder: number[] = seriesMapping.reduce((acc: number[], series, idx) => {
+    const seriesType = (series as { type?: string }).type;
+    if (seriesType === 'bar') acc.push(idx);
+    return acc;
+  }, []);
+
+  // Only need to loop through first dataset source since getCommonTimeScale ensures xAxis timestamps are consistent
+  const firstTimeSeriesValues = data[0]?.values;
+
+  for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
+    const currentSeries = seriesMapping[seriesIdx];
+    const hasCurrentSeries = currentSeries !== undefined;
+
+    if (hasCurrentSeries) {
+      const currentMetadata = seriesMetadata?.[seriesIdx];
+      const currentDataset = totalSeries > 0 ? data[seriesIdx] : undefined;
+
+      if (currentDataset !== undefined && currentDataset !== null) {
+        const currentDatasetValues: TimeSeriesValueTuple[] = currentDataset.values;
+        const hasValidDatasetValues = currentDatasetValues !== undefined && Array.isArray(currentDatasetValues);
+
+        if (hasValidDatasetValues && Array.isArray(data)) {
+          const lineSeries = currentSeries as LineSeriesOption;
+          const seriesType = currentSeries.type ?? 'line';
+          const isBarSeries = seriesType === 'bar';
+          const isLineSeries = seriesType === 'line';
+          const currentSeriesName = lineSeries.name ? lineSeries.name.toString() : '';
+          const markerColor = lineSeries.color ?? '#000';
+          const stackId = lineSeries.stack;
+
+          for (let datumIdx = 0; datumIdx < currentDatasetValues.length; datumIdx++) {
+            const nearbyTimeSeries = currentDatasetValues[datumIdx];
+            const hasValidTimeSeries = nearbyTimeSeries !== undefined && Array.isArray(nearbyTimeSeries);
+
+            if (hasValidTimeSeries) {
+              const xValue = nearbyTimeSeries[0];
+              const yValue = nearbyTimeSeries[1];
+              const hasValidYValue = yValue !== undefined && yValue !== null;
+              const isAtClosestTimestamp = closestTimestamp === xValue;
+
+              if (hasValidYValue && isAtClosestTimestamp) {
+                const visualY = calculateVisualYForSeries({
+                  rawY: yValue,
+                  stackId,
+                  stackTotals,
+                });
+
+                if (isBarSeries) {
+                  const hasValidMousePixelX = mousePixelX !== undefined;
+
+                  if (hasValidMousePixelX) {
+                    const prevTimestamp = firstTimeSeriesValues?.[datumIdx - 1]?.[0];
+                    const nextTimestamp = firstTimeSeriesValues?.[datumIdx + 1]?.[0];
+                    const timestampCenterX = getPixelXFromGrid(chart, xValue);
+
+                    const bandwidth = calculateBarBandwidth({
+                      timestampCenterX,
+                      prevTimestamp,
+                      nextTimestamp,
+                      chart,
+                    });
+
+                    const { segLeft, segRight } = calculateBarSegmentBounds({
+                      timestampCenterX,
+                      bandwidth,
+                      seriesIdx,
+                      barSeriesOrder,
+                    });
+
+                    const { lower, upper } = calculateBarYBounds({
+                      visualY,
+                      rawY: yValue,
+                      isStacked: stackId !== undefined,
+                    });
+
+                    const isHoveringXSegment = mousePixelX >= segLeft && mousePixelX <= segRight;
+                    const isHoveringYBounds = stackId !== undefined ? cursorY >= lower && cursorY <= upper : true;
+                    const isHoveringBar = isHoveringXSegment && isHoveringYBounds;
+
+                    if (isHoveringBar) {
+                      const segmentCenterX = (segLeft + segRight) / 2;
+                      const distance = Math.abs(segmentCenterX - mousePixelX);
+                      const isSelected = selectedSeriesIdx === seriesIdx;
+                      const formattedY = formatValue(yValue, format);
+
+                      candidates.push({
+                        seriesIdx,
+                        datumIdx,
+                        seriesName: currentSeriesName,
+                        date: closestTimestamp,
+                        x: xValue,
+                        y: yValue,
+                        formattedY,
+                        markerColor: markerColor.toString(),
+                        metadata: currentMetadata,
+                        isSelected,
+                        visualY,
+                        distance,
+                      });
+                    }
+                  }
+                } else if (isLineSeries) {
+                  const distance = Math.abs(visualY - cursorY);
+                  const isWithinYBuffer = distance <= yBuffer;
+
+                  if (isWithinYBuffer) {
+                    const isSelected = selectedSeriesIdx === seriesIdx;
+                    const formattedY = formatValue(yValue, format);
+
+                    candidates.push({
+                      seriesIdx,
+                      datumIdx,
+                      seriesName: currentSeriesName,
+                      date: closestTimestamp,
+                      x: xValue,
+                      y: yValue,
+                      formattedY,
+                      markerColor: markerColor.toString(),
+                      metadata: currentMetadata,
+                      isSelected,
+                      visualY,
+                      distance,
+                    });
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
+/**
+ * Processes a list of candidates to determine which series to emphasize and formats them for the tooltip.
+ */
+export function processCandidates(
+  candidates: Candidate[],
+  winner: Candidate
+): {
+  currentNearbySeriesData: NearbySeriesArray;
+  emphasizedSeriesIndexes: number[];
+  nonEmphasizedSeriesIndexes: number[];
+  emphasizedDatapoints: DatapointInfo[];
+  duplicateDatapoints: DatapointInfo[];
+  nearbySeriesIndexes: number[];
+} {
+  const currentNearbySeriesData: NearbySeriesArray = [];
+  const emphasizedSeriesIndexes: number[] = [];
+  const nonEmphasizedSeriesIndexes: number[] = [];
+  const emphasizedDatapoints: DatapointInfo[] = [];
+  const duplicateDatapoints: DatapointInfo[] = [];
+  const nearbySeriesIndexes: number[] = candidates.map((c) => c.seriesIdx);
+  const yValueCounts: Map<number, number> = new Map();
+
+  for (const candidate of candidates) {
+    const isClosestToCursor = candidate === winner;
+
+    if (isClosestToCursor) {
+      emphasizedSeriesIndexes.push(candidate.seriesIdx);
+
+      const duplicateValuesCount = yValueCounts.get(candidate.visualY) ?? 0;
+      const hasDuplicateValues = duplicateValuesCount > 0;
+      yValueCounts.set(candidate.visualY, duplicateValuesCount + 1);
+
+      if (hasDuplicateValues) {
+        duplicateDatapoints.push({
+          seriesIndex: candidate.seriesIdx,
+          dataIndex: candidate.datumIdx,
+          seriesName: candidate.seriesName,
+          yValue: candidate.visualY,
+        });
+      }
+
+      emphasizedDatapoints.push({
+        seriesIndex: candidate.seriesIdx,
+        dataIndex: candidate.datumIdx,
+        seriesName: candidate.seriesName,
+        yValue: candidate.visualY,
+      });
+    } else {
+      nonEmphasizedSeriesIndexes.push(candidate.seriesIdx);
+    }
+
+    currentNearbySeriesData.push({
+      seriesIdx: candidate.seriesIdx,
+      datumIdx: candidate.datumIdx,
+      seriesName: candidate.seriesName,
+      date: candidate.date,
+      x: candidate.x,
+      y: candidate.y,
+      formattedY: candidate.formattedY,
+      markerColor: candidate.markerColor,
+      isClosestToCursor,
+      metadata: candidate.metadata,
+      isSelected: candidate.isSelected,
+    });
+  }
+
+  return {
+    currentNearbySeriesData,
+    emphasizedSeriesIndexes,
+    nonEmphasizedSeriesIndexes,
+    emphasizedDatapoints,
+    duplicateDatapoints,
+    nearbySeriesIndexes,
+  };
+}
+
 // LOGZ.IO CHANGE END:: Tooltip is not behaving correctly [APPZ-1418]

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ECharts as EChartsInstance } from 'echarts/core';
 import { Theme } from '@mui/material';
 import {
   CursorCoordinates,
@@ -122,3 +123,120 @@ export function getTooltipStyles(
     },
   };
 }
+
+// LOGZ.IO CHANGE START:: Tooltip is not behaving correctly [APPZ-1418]
+
+export function getPixelXFromGrid(chart: EChartsInstance, xValue: number): number {
+  const pixelValue = chart.convertToPixel('grid', [xValue, 0]);
+  return pixelValue[0] ?? 0;
+}
+
+export function calculateVisualYForSeries({
+  rawY,
+  stackId,
+  stackTotals,
+}: {
+  rawY: number;
+  stackId?: string;
+  stackTotals: Map<string, number>;
+}): number {
+  if (stackId === undefined) {
+    return rawY;
+  }
+
+  const currentStackTotal = stackTotals.get(stackId) ?? 0;
+  const visualY = currentStackTotal + rawY;
+  stackTotals.set(stackId, visualY);
+
+  return visualY;
+}
+
+export function calculateBarBandwidth({
+  timestampCenterX,
+  prevTimestamp,
+  nextTimestamp,
+  chart,
+  defaultBandwidth = 20,
+}: {
+  timestampCenterX: number;
+  prevTimestamp: number | undefined;
+  nextTimestamp: number | undefined;
+  chart: EChartsInstance;
+  defaultBandwidth?: number;
+}): number {
+  const hasLeftNeighbor = prevTimestamp !== undefined;
+  const hasRightNeighbor = nextTimestamp !== undefined;
+
+  if (!hasLeftNeighbor && !hasRightNeighbor) {
+    return defaultBandwidth;
+  }
+
+  let leftTimestampX: number | null = null;
+  let rightTimestampX: number | null = null;
+
+  if (hasLeftNeighbor) {
+    leftTimestampX = getPixelXFromGrid(chart, prevTimestamp);
+  }
+
+  if (hasRightNeighbor) {
+    rightTimestampX = getPixelXFromGrid(chart, nextTimestamp);
+  }
+
+  if (leftTimestampX !== null && rightTimestampX !== null) {
+    const distanceToLeft = Math.abs(timestampCenterX - leftTimestampX);
+    const distanceToRight = Math.abs(rightTimestampX - timestampCenterX);
+    return Math.min(distanceToLeft, distanceToRight);
+  }
+
+  if (leftTimestampX !== null) {
+    return Math.abs(timestampCenterX - leftTimestampX);
+  }
+
+  if (rightTimestampX !== null) {
+    return Math.abs(rightTimestampX - timestampCenterX);
+  }
+
+  return defaultBandwidth;
+}
+
+export function calculateBarSegmentBounds({
+  timestampCenterX,
+  bandwidth,
+  seriesIdx,
+  barSeriesOrder,
+}: {
+  timestampCenterX: number;
+  bandwidth: number;
+  seriesIdx: number;
+  barSeriesOrder: number[];
+}): { segLeft: number; segRight: number } {
+  const groupLeft = timestampCenterX - bandwidth / 2;
+  const barsInGroup = barSeriesOrder.length || 1;
+  const idxInBars = Math.max(0, barSeriesOrder.indexOf(seriesIdx));
+  const segmentWidth = bandwidth / barsInGroup;
+  const segLeft = groupLeft + idxInBars * segmentWidth;
+  const segRight = segLeft + segmentWidth;
+
+  return { segLeft, segRight };
+}
+
+export function calculateBarYBounds({
+  visualY,
+  rawY,
+  isStacked,
+}: {
+  visualY: number;
+  rawY: number;
+  isStacked: boolean;
+}): {
+  base: number;
+  lower: number;
+  upper: number;
+} {
+  const base = isStacked ? visualY - rawY : 0;
+  const lower = Math.min(base, visualY);
+  const upper = Math.max(base, visualY);
+
+  return { base, lower, upper };
+}
+// LOGZ.IO CHANGE END:: Tooltip is not behaving correctly [APPZ-1418]

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -13,8 +13,8 @@
 
 import { ECharts as EChartsInstance } from 'echarts/core';
 import { Theme } from '@mui/material';
-import { formatValue, TimeSeries, TimeSeriesMetadata, FormatOptions, TimeSeriesValueTuple } from '@perses-dev/core';
-import { LineSeriesOption } from 'echarts/charts';
+import { formatValue, TimeSeries, TimeSeriesMetadata, FormatOptions } from '@perses-dev/core';
+import { LineSeriesOption, BarSeriesOption } from 'echarts/charts';
 import { DatapointInfo, TimeChartSeriesMapping } from '../model';
 import {
   CursorCoordinates,
@@ -222,6 +222,100 @@ export function calculateBarYBounds({ visualY, rawY, isStacked }: CalculateBarYB
   return { base, lower, upper };
 }
 
+/**
+ * Creates candidates for all series at a given timestamp when hovering over a bar chart.
+ * This function is responsible for building the complete list of candidates for bar group tooltips.
+ */
+export function createBarGroupCandidates({
+  data,
+  seriesMapping,
+  closestTimestamp,
+  hoveredBarInfo,
+  selectedSeriesIdx,
+}: {
+  data: TimeSeries[];
+  seriesMapping: TimeChartSeriesMapping;
+  closestTimestamp: number;
+  hoveredBarInfo: { seriesIdx: number; distance: number };
+  selectedSeriesIdx?: number | null;
+}): Candidate[] {
+  const candidates: Candidate[] = [];
+  const totalSeries = data.length;
+  const stackTotals = new Map<string, number>();
+
+  for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
+    const currentSeries = seriesMapping[seriesIdx];
+    const hasCurrentSeries = currentSeries !== undefined;
+
+    if (hasCurrentSeries) {
+      const currentDataset = data[seriesIdx];
+      const hasValidDataset = currentDataset !== undefined && currentDataset !== null;
+      const hasDatasetValues = currentDataset?.values !== undefined && currentDataset?.values !== null;
+
+      if (hasValidDataset && hasDatasetValues) {
+        const datumAtTimestamp = currentDataset.values.find(([ts]) => ts === closestTimestamp);
+        const hasDatumAtTimestamp = datumAtTimestamp !== undefined;
+
+        if (hasDatumAtTimestamp) {
+          const [xValue, yValue] = datumAtTimestamp;
+          const hasValidYValue = yValue !== null && yValue !== undefined;
+
+          if (hasValidYValue) {
+            const datumIdx = currentDataset.values.findIndex(([ts]) => ts === closestTimestamp);
+
+            const hasSelectedSeriesIdx = selectedSeriesIdx !== null && selectedSeriesIdx !== undefined;
+            const isSelected = hasSelectedSeriesIdx && seriesIdx === selectedSeriesIdx;
+
+            let distance: number;
+            if (seriesIdx === hoveredBarInfo.seriesIdx) {
+              distance = hoveredBarInfo.distance;
+            } else {
+              distance = Infinity;
+            }
+
+            const stackId = (currentSeries as LineSeriesOption | BarSeriesOption).stack;
+            const visualY = calculateVisualYForSeries({
+              rawY: yValue,
+              stackId,
+              stackTotals,
+            });
+
+            let seriesName: string;
+            if (currentSeries.name !== undefined) {
+              seriesName = String(currentSeries.name);
+            } else {
+              seriesName = '';
+            }
+
+            let markerColor: string;
+            if (currentSeries.color !== undefined) {
+              markerColor = String(currentSeries.color);
+            } else {
+              markerColor = '#000';
+            }
+
+            candidates.push({
+              seriesIdx,
+              datumIdx,
+              seriesName,
+              date: closestTimestamp,
+              markerColor,
+              x: xValue,
+              y: yValue,
+              formattedY: '',
+              visualY,
+              distance,
+              isSelected,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return candidates;
+}
+
 export function findClosestCandidate(candidates: Candidate[]): Candidate {
   if (candidates.length === 0) {
     throw new Error('Cannot find closest candidate in an empty array.');
@@ -244,7 +338,10 @@ export function findClosestCandidate(candidates: Candidate[]): Candidate {
 }
 
 /**
- * Gathers all series points that are close to the user's cursor.
+ * Gathers all candidate series that could match the cursor position.
+ * This is Pass 1 of the two-pass system.
+ * Uses a "detect, then build" pattern: detects bar hover in a single pass,
+ * then builds appropriate candidates (bar group or line series).
  */
 export function gatherCandidates({
   data,
@@ -255,7 +352,6 @@ export function gatherCandidates({
   chart,
   mousePixelX,
   seriesMetadata,
-  format,
   selectedSeriesIdx,
 }: {
   data: TimeSeries[];
@@ -266,20 +362,19 @@ export function gatherCandidates({
   chart: EChartsInstance;
   mousePixelX?: number;
   seriesMetadata?: TimeSeriesMetadata[];
-  format?: FormatOptions;
   selectedSeriesIdx?: number | null;
 }): Candidate[] {
-  const candidates: Candidate[] = [];
+  const lineCandidates: Candidate[] = [];
   const totalSeries = data.length;
-  const stackTotals: Map<string, number> = new Map();
+  const stackTotals = new Map<string, number>();
+
+  let hoveredBarInfo: { seriesIdx: number; distance: number } | null = null;
 
   const barSeriesOrder: number[] = seriesMapping.reduce((acc: number[], series, idx) => {
-    const seriesType = (series as { type?: string }).type;
-    if (seriesType === 'bar') acc.push(idx);
+    if ((series as { type?: string }).type === 'bar') acc.push(idx);
     return acc;
   }, []);
 
-  // Only need to loop through first dataset source since getCommonTimeScale ensures xAxis timestamps are consistent
   const firstTimeSeriesValues = data[0]?.values;
 
   for (let seriesIdx = 0; seriesIdx < totalSeries; seriesIdx++) {
@@ -287,115 +382,139 @@ export function gatherCandidates({
     const hasCurrentSeries = currentSeries !== undefined;
 
     if (hasCurrentSeries) {
-      const currentMetadata = seriesMetadata?.[seriesIdx];
-      const currentDataset = totalSeries > 0 ? data[seriesIdx] : undefined;
+      const currentDataset = data[seriesIdx];
+      const hasValidDataset = currentDataset !== undefined && currentDataset !== null;
+      const hasDatasetValues = currentDataset?.values !== undefined && currentDataset?.values !== null;
 
-      if (currentDataset !== undefined && currentDataset !== null) {
-        const currentDatasetValues: TimeSeriesValueTuple[] = currentDataset.values;
-        const hasValidDatasetValues = currentDatasetValues !== undefined && Array.isArray(currentDatasetValues);
+      if (hasValidDataset && hasDatasetValues) {
+        const datumAtTimestamp = currentDataset.values.find(([ts]) => ts === closestTimestamp);
+        const hasDatumAtTimestamp = datumAtTimestamp !== undefined;
 
-        if (hasValidDatasetValues && Array.isArray(data)) {
-          const lineSeries = currentSeries as LineSeriesOption;
-          const seriesType = currentSeries.type ?? 'line';
-          const isBarSeries = seriesType === 'bar';
-          const isLineSeries = seriesType === 'line';
-          const currentSeriesName = lineSeries.name ? lineSeries.name.toString() : '';
-          const markerColor = lineSeries.color ?? '#000';
-          const stackId = lineSeries.stack;
+        if (hasDatumAtTimestamp) {
+          const [xValue, yValue] = datumAtTimestamp;
+          const hasValidYValue = yValue !== null && yValue !== undefined;
 
-          for (let datumIdx = 0; datumIdx < currentDatasetValues.length; datumIdx++) {
-            const nearbyTimeSeries = currentDatasetValues[datumIdx];
-            const hasValidTimeSeries = nearbyTimeSeries !== undefined && Array.isArray(nearbyTimeSeries);
+          if (hasValidYValue) {
+            let seriesType: string;
+            if (currentSeries.type !== undefined) {
+              seriesType = currentSeries.type;
+            } else {
+              seriesType = 'line';
+            }
+            const currentMetadata = seriesMetadata?.[seriesIdx];
 
-            if (hasValidTimeSeries) {
-              const xValue = nearbyTimeSeries[0];
-              const yValue = nearbyTimeSeries[1];
-              const hasValidYValue = yValue !== undefined && yValue !== null;
-              const isAtClosestTimestamp = closestTimestamp === xValue;
+            let currentSeriesName: string;
+            if (currentSeries.name !== undefined) {
+              currentSeriesName = String(currentSeries.name);
+            } else {
+              currentSeriesName = '';
+            }
 
-              if (hasValidYValue && isAtClosestTimestamp) {
-                const visualY = calculateVisualYForSeries({
-                  rawY: yValue,
-                  stackId,
-                  stackTotals,
+            let markerColor: string;
+            if (currentSeries.color !== undefined) {
+              markerColor = String(currentSeries.color);
+            } else {
+              markerColor = '#000';
+            }
+
+            if (seriesType === 'line') {
+              const stackId = (currentSeries as LineSeriesOption).stack;
+              const visualY = calculateVisualYForSeries({
+                rawY: yValue,
+                stackId,
+                stackTotals,
+              });
+
+              const verticalDistance = Math.abs(visualY - cursorY);
+              const isWithinYBuffer = verticalDistance <= yBuffer;
+
+              if (isWithinYBuffer) {
+                const datumIdx = currentDataset.values.findIndex(([ts]) => ts === closestTimestamp);
+                const hasSelectedSeriesIdx = selectedSeriesIdx !== null && selectedSeriesIdx !== undefined;
+                const isSelected = hasSelectedSeriesIdx && seriesIdx === selectedSeriesIdx;
+
+                lineCandidates.push({
+                  seriesIdx,
+                  datumIdx,
+                  seriesName: currentSeriesName,
+                  date: closestTimestamp,
+                  markerColor,
+                  x: xValue,
+                  y: yValue,
+                  formattedY: '',
+                  visualY,
+                  distance: verticalDistance,
+                  isSelected,
+                  metadata: currentMetadata,
+                });
+              }
+            } else if (seriesType === 'bar') {
+              const hasValidMousePixelX = mousePixelX !== undefined;
+
+              if (hasValidMousePixelX) {
+                const timestampIdx = firstTimeSeriesValues?.findIndex(([ts]) => ts === closestTimestamp) ?? -1;
+
+                let prevTimestamp: number | undefined;
+                if (timestampIdx > 0) {
+                  prevTimestamp = firstTimeSeriesValues?.[timestampIdx - 1]?.[0];
+                } else {
+                  prevTimestamp = undefined;
+                }
+
+                let nextTimestamp: number | undefined;
+                const firstTimeSeriesLength = firstTimeSeriesValues?.length ?? 0;
+                const isValidTimestampIdx = timestampIdx >= 0;
+                const hasNextTimestamp = timestampIdx < firstTimeSeriesLength - 1;
+
+                if (isValidTimestampIdx && hasNextTimestamp) {
+                  nextTimestamp = firstTimeSeriesValues?.[timestampIdx + 1]?.[0];
+                } else {
+                  nextTimestamp = undefined;
+                }
+
+                const timestampCenterX = getPixelXFromGrid(chart, xValue);
+
+                const bandwidth = calculateBarBandwidth({
+                  timestampCenterX,
+                  prevTimestamp,
+                  nextTimestamp,
+                  chart,
                 });
 
-                if (isBarSeries) {
-                  const hasValidMousePixelX = mousePixelX !== undefined;
+                const { segLeft, segRight } = calculateBarSegmentBounds({
+                  timestampCenterX,
+                  bandwidth,
+                  seriesIdx,
+                  barSeriesOrder,
+                });
 
-                  if (hasValidMousePixelX) {
-                    const prevTimestamp = firstTimeSeriesValues?.[datumIdx - 1]?.[0];
-                    const nextTimestamp = firstTimeSeriesValues?.[datumIdx + 1]?.[0];
-                    const timestampCenterX = getPixelXFromGrid(chart, xValue);
+                const isWithinXBounds = mousePixelX >= segLeft && mousePixelX <= segRight;
 
-                    const bandwidth = calculateBarBandwidth({
-                      timestampCenterX,
-                      prevTimestamp,
-                      nextTimestamp,
-                      chart,
-                    });
+                if (isWithinXBounds) {
+                  const stackId = (currentSeries as BarSeriesOption).stack;
+                  const hasStackId = stackId !== undefined;
+                  let isHoveringYBounds = true;
 
-                    const { segLeft, segRight } = calculateBarSegmentBounds({
-                      timestampCenterX,
-                      bandwidth,
-                      seriesIdx,
-                      barSeriesOrder,
-                    });
-
+                  if (hasStackId) {
+                    const visualY = calculateVisualYForSeries({ rawY: yValue, stackId, stackTotals });
                     const { lower, upper } = calculateBarYBounds({
                       visualY,
                       rawY: yValue,
-                      isStacked: stackId !== undefined,
+                      isStacked: true,
                     });
-
-                    const isHoveringXSegment = mousePixelX >= segLeft && mousePixelX <= segRight;
-                    const isHoveringYBounds = stackId !== undefined ? cursorY >= lower && cursorY <= upper : true;
-                    const isHoveringBar = isHoveringXSegment && isHoveringYBounds;
-
-                    if (isHoveringBar) {
-                      const segmentCenterX = (segLeft + segRight) / 2;
-                      const distance = Math.abs(segmentCenterX - mousePixelX);
-                      const isSelected = selectedSeriesIdx === seriesIdx;
-                      const formattedY = formatValue(yValue, format);
-
-                      candidates.push({
-                        seriesIdx,
-                        datumIdx,
-                        seriesName: currentSeriesName,
-                        date: closestTimestamp,
-                        x: xValue,
-                        y: yValue,
-                        formattedY,
-                        markerColor: markerColor.toString(),
-                        metadata: currentMetadata,
-                        isSelected,
-                        visualY,
-                        distance,
-                      });
-                    }
+                    isHoveringYBounds = cursorY >= lower && cursorY <= upper;
                   }
-                } else if (isLineSeries) {
-                  const distance = Math.abs(visualY - cursorY);
-                  const isWithinYBuffer = distance <= yBuffer;
 
-                  if (isWithinYBuffer) {
-                    const isSelected = selectedSeriesIdx === seriesIdx;
-                    const formattedY = formatValue(yValue, format);
+                  if (isHoveringYBounds) {
+                    const segmentCenter = (segLeft + segRight) / 2;
+                    const distance = Math.abs(mousePixelX - segmentCenter);
 
-                    candidates.push({
-                      seriesIdx,
-                      datumIdx,
-                      seriesName: currentSeriesName,
-                      date: closestTimestamp,
-                      x: xValue,
-                      y: yValue,
-                      formattedY,
-                      markerColor: markerColor.toString(),
-                      metadata: currentMetadata,
-                      isSelected,
-                      visualY,
-                      distance,
-                    });
+                    const isFirstHoveredBar = hoveredBarInfo === null;
+                    const isCloserThanCurrentHoveredBar = hoveredBarInfo !== null && distance < hoveredBarInfo.distance;
+
+                    if (isFirstHoveredBar || isCloserThanCurrentHoveredBar) {
+                      hoveredBarInfo = { seriesIdx, distance };
+                    }
                   }
                 }
               }
@@ -406,7 +525,17 @@ export function gatherCandidates({
     }
   }
 
-  return candidates;
+  if (hoveredBarInfo !== null) {
+    return createBarGroupCandidates({
+      data,
+      seriesMapping,
+      closestTimestamp,
+      hoveredBarInfo,
+      selectedSeriesIdx,
+    });
+  }
+
+  return lineCandidates;
 }
 
 /**
@@ -414,7 +543,8 @@ export function gatherCandidates({
  */
 export function processCandidates(
   candidates: Candidate[],
-  winner: Candidate
+  winner: Candidate,
+  format?: FormatOptions
 ): {
   currentNearbySeriesData: NearbySeriesArray;
   emphasizedSeriesIndexes: number[];
@@ -433,6 +563,7 @@ export function processCandidates(
 
   for (const candidate of candidates) {
     const isClosestToCursor = candidate === winner;
+    const formattedY = formatValue(candidate.y, format);
 
     if (isClosestToCursor) {
       emphasizedSeriesIndexes.push(candidate.seriesIdx);
@@ -467,7 +598,7 @@ export function processCandidates(
       date: candidate.date,
       x: candidate.x,
       y: candidate.y,
-      formattedY: candidate.formattedY,
+      formattedY,
       markerColor: candidate.markerColor,
       isClosestToCursor,
       metadata: candidate.metadata,

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -113,7 +113,6 @@ export function getTooltipStyles(
     maxHeight: adjustedMaxHeight ?? TOOLTIP_MAX_HEIGHT,
     padding: 0,
     position: 'absolute',
-
     top: 0,
     left: 0,
     borderRadius: '6px',

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -113,6 +113,7 @@ export function getTooltipStyles(
     maxHeight: adjustedMaxHeight ?? TOOLTIP_MAX_HEIGHT,
     padding: 0,
     position: 'absolute',
+
     top: 0,
     left: 0,
     borderRadius: '6px',
@@ -232,12 +233,14 @@ export function createBarGroupCandidates({
   closestTimestamp,
   hoveredBarInfo,
   selectedSeriesIdx,
+  seriesMetadata,
 }: {
   data: TimeSeries[];
   seriesMapping: TimeChartSeriesMapping;
   closestTimestamp: number;
   hoveredBarInfo: { seriesIdx: number; distance: number };
   selectedSeriesIdx?: number | null;
+  seriesMetadata?: TimeSeriesMetadata[];
 }): Candidate[] {
   const candidates: Candidate[] = [];
   const totalSeries = data.length;
@@ -280,6 +283,8 @@ export function createBarGroupCandidates({
               stackTotals,
             });
 
+            const currentMetadata = seriesMetadata?.[seriesIdx];
+
             let seriesName: string;
             if (currentSeries.name !== undefined) {
               seriesName = String(currentSeries.name);
@@ -306,6 +311,7 @@ export function createBarGroupCandidates({
               visualY,
               distance,
               isSelected,
+              metadata: currentMetadata,
             });
           }
         }
@@ -532,6 +538,7 @@ export function gatherCandidates({
       closestTimestamp,
       hoveredBarInfo,
       selectedSeriesIdx,
+      seriesMetadata,
     });
   }
 


### PR DESCRIPTION
## Feat: Implement robust multi-strategy tooltip proximity logic

### 1. Summary of Changes

This PR completely overhauls the time-series tooltip logic to fix multiple critical bugs and usability issues. It introduces a robust, multi-strategy proximity-checking system that correctly handles stacked lines, grouped bars, and accessibility for low-value bars, all while maintaining O(n) performance. The solution implements a two-pass candidate selection architecture and conditional proximity strategies based on chart type (line vs. bar) and stacking configuration, ensuring intuitive and accurate tooltip behavior across all visualization scenarios.

### 2. The Evolution of the Fix

#### Fix 1: Stacked Line Charts (O(n) Visual Y Calculation)

**Problem:** The original proximity logic compared the cursor's Y-position against raw series data values. In stacked line charts, multiple series share the same raw value (e.g., three series each with value `1`) but render at different visual Y positions (y=1, y=2, y=3 due to stacking). The tooltip only activated when hovering the base series because the logic checked `|cursorY - rawY|`, ignoring the cumulative stack offset.

**Solution:** Introduced a `stackTotals: Map<string, number>` that accumulates running totals per stack in a single O(n) pass. For each series at the closest timestamp, we compute `visualY = stackTotals[stackId] + rawY`, then update `stackTotals[stackId] = visualY`. This reflects the true rendered Y-position. Proximity checks now use `visualY` instead of `rawY`, correctly triggering tooltips for all stacked series.

#### Fix 2: Proximity vs. Closest (Two-Pass Winner Selection)

**Problem:** The initial fix correctly identified all series within the vertical `yBuffer`, but emphasized *all* of them simultaneously. When multiple series were close together (e.g., visualY=10 and visualY=11 with cursor at y=10.8), both appeared emphasized in the tooltip, creating visual noise and unclear UX.

**Solution:** Refactored to a **two-pass architecture**:
- **Pass 1 (Gather):** Collect all series within `yBuffer` into a `candidates` array, storing each with its computed `distance` metric
- **Pass 2 (Select):** Scan candidates to find the single `winner` with minimum distance, then iterate candidates again to emphasize only the winner and downplay all others

This ensures exactly one series receives emphasis regardless of how many are nearby, providing clear, predictable visual feedback.

#### Fix 3: Bar Chart X-Dominant Logic

**Problem:** The vertical "closest-Y" heuristic failed catastrophically for grouped bar charts. Example: hovering the bottom of a tall bar (value 400) could incorrectly emphasize a neighboring short bar (value 20) because 20 was numerically closer to the cursor's Y-coordinate. This violated user intent—they were clearly hovering *over* the tall bar.

**Solution:** Added conditional logic based on `series.type`. For bars:
1. Compute the timestamp's pixel center via `convertToPixel('grid', [xValue, 0])`
2. Estimate pixel `bandwidth` from neighboring timestamp centers
3. Partition bandwidth among bar series to calculate per-bar `segLeft`/`segRight` bounds
4. Check if `mousePixelX ∈ [segLeft, segRight]` (x-segment hit-test)
5. Check if `cursorY ∈ [base, top]` (y-bounds check for stacked differentiation)
6. Use horizontal distance from segment center as the `distance` metric

This makes bar selection x-axis dominant, correctly identifying the bar under the cursor's horizontal position.

#### Fix 4: Bar Chart Accessibility (Conditional Y-Bounds)

**Problem:** The strict y-bounds check from Fix 3 created a "pixel-hunt" usability flaw for regular/grouped bars. A bar with value 15 next to a bar with value 200,000 required the user to position their cursor in the tiny y=[0,15] region to select the small bar—effectively making it un-selectable.

**Solution:** Introduced a `stackId`-conditional y-bounds check:
```typescript
const isHoveringYBounds = stackId !== undefined ? cursorY >= lower && cursorY <= upper : true;
```
- **Stacked bars (`stackId !== undefined`):** Full y-bounds enforcement remains, as multiple series share the same x-segment and y-position is the only distinguishing factor
- **Regular/grouped bars (`stackId === undefined`):** Y-bounds check is bypassed—any cursor position within the bar's x-segment selects that bar, regardless of Y

This eliminates pixel-hunting while preserving correctness for stacked bars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors time-series tooltip to a two-pass candidate selection with stacked-line visual Y and bar x-segment hit-testing, extracts shared types/utils, updates tests, and adds onEvents passthrough to PieChart.
> 
> - **Tooltip (Time Series)**:
>   - Implements two-pass proximity selection (`gatherCandidates` → `findClosestCandidate`/`processCandidates`).
>   - Adds stacked line support via visual Y computation and per-stack accumulation.
>   - Adds grouped/stacked bar hit-testing: pixel bandwidth, per-bar segment bounds, and conditional Y-bounds.
>   - Exposes `mousePixelX` to proximity logic; adjusts nearby-series multipliers.
>   - Extracts shared types to `TimeSeriesTooltip/types.ts` and moves core logic to `utils.ts`.
>   - Updates imports in `TooltipHeader`, `TooltipContent`, `TooltipActions`, and `tooltip-model` to use new types.
>   - Sends highlight/downplay actions via `batchDispatchNearbySeriesActions` using processed candidates.
> - **Tests**:
>   - Updates `nearby-series.test.ts` `getYBuffer` expectation for larger interval.
> - **PieChart**:
>   - Adds `onEvents` prop passthrough to `EChart`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 524be2fc9204e8a8e1b31482a29c160e4691f1a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->