### PR TITLE
APPZ-359 Performance - Add usage for metadata

### DIFF
--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { CSSProperties, memo, useEffect, useLayoutEffect, useRef } from 'react';
+import { CSSProperties, memo, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { ECharts, EChartsCoreOption, init, connect, use } from 'echarts/core';
 import { Box, SxProps, Theme } from '@mui/material';
 import isEqual from 'lodash/isEqual';
@@ -211,25 +211,38 @@ export const EChart = memo(function EChart<T>({
     };
   }, [onEvents]);
 
+  const updateSize = useMemo(
+    () =>
+      debounce(
+        () => {
+          if (!chartElement.current) return;
+          chartElement.current.resize();
+        },
+        200,
+        { leading: true }
+      ),
+    []
+  );
+
   // TODO: re-evaluate how this is triggered. It's technically working right
   // now because the sx prop is an object that gets re-created, but that also
   // means it runs unnecessarily some of the time and theoretically might
   // not run in some other cases. Maybe it should use a resize observer?
   useEffect(() => {
-    // TODO: fix this debouncing. This likely isn't working as intended because
-    // the debounced function is re-created every time this useEffect is called.
-    const updateSize = debounce(
-      () => {
-        if (!chartElement.current) return;
-        chartElement.current.resize();
-      },
-      200,
-      {
-        leading: true,
-      }
-    );
-    updateSize();
-  }, [sx, style]);
+    if (!containerRef.current) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateSize();
+    });
+
+    if (parent) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    return (): void => {
+      resizeObserver.disconnect();
+    };
+  }, [updateSize]);
 
   return <Box ref={containerRef} sx={sx} style={style}></Box>;
 });

--- a/ui/components/src/EChart/EChart.tsx
+++ b/ui/components/src/EChart/EChart.tsx
@@ -211,6 +211,7 @@ export const EChart = memo(function EChart<T>({
     };
   }, [onEvents]);
 
+  // LOGZ.IO CHANGE START:: APPZ-359-unidash-performance-issues-when-loading-high-number-of-serieses
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -232,6 +233,7 @@ export const EChart = memo(function EChart<T>({
       cancelAnimationFrame(rafId);
     };
   }, []);
+  // LOGZ.IO CHANGE END:: APPZ-359-unidash-performance-issues-when-loading-high-number-of-serieses
 
   return <Box ref={containerRef} sx={sx} style={style}></Box>;
 });

--- a/ui/components/src/LineChart/LineChart.tsx
+++ b/ui/components/src/LineChart/LineChart.tsx
@@ -64,6 +64,11 @@ use([
   CanvasRenderer,
 ]);
 
+const SX = {
+  width: '100%',
+  height: '100%',
+};
+
 export interface LineChartProps {
   height: number;
   data: EChartsDataFormat;
@@ -314,10 +319,7 @@ export const LineChart = forwardRef<ChartInstance, LineChartProps>(function Line
           />
         )}
       <EChart
-        sx={{
-          width: '100%',
-          height: '100%',
-        }}
+        sx={SX}
         option={option}
         theme={chartsTheme.echartsTheme}
         onEvents={handleEvents}

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { forwardRef, MouseEvent, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { Box } from '@mui/material';
+import { Box, SxProps, Theme } from '@mui/material';
 import merge from 'lodash/merge';
 import isEqual from 'lodash/isEqual';
 import { DatasetOption } from 'echarts/types/dist/shared';
@@ -70,6 +70,10 @@ use([
   CanvasRenderer,
 ]);
 
+const SX: SxProps<Theme> = {
+  width: '100%',
+  height: '100%',
+};
 export interface TimeChartProps {
   height: number;
   data: TimeSeries[];
@@ -451,10 +455,7 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
           />
         )}
       <EChart
-        sx={{
-          width: '100%',
-          height: '100%',
-        }}
+        sx={SX}
         option={option}
         theme={chartsTheme.echartsTheme}
         onEvents={handleEvents}

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.test.tsx
@@ -13,12 +13,20 @@
 
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
+import { VirtuosoMockContext } from 'react-virtuoso';
 import { TooltipContent, TooltipContentProps } from './TooltipContent';
 import { EMPHASIZED_SERIES_DESCRIPTION, NEARBY_SERIES_DESCRIPTION } from './tooltip-model';
 
+const MOCK_VIEWPORT_HEIGHT = 1000;
+const MOCK_ITEM_HEIGHT = 50;
+
 describe('TooltipContent', () => {
   const renderComponent = (props: TooltipContentProps): void => {
-    render(<TooltipContent {...props} />);
+    render(
+      <VirtuosoMockContext.Provider value={{ viewportHeight: MOCK_VIEWPORT_HEIGHT, itemHeight: MOCK_ITEM_HEIGHT }}>
+        <TooltipContent {...props} />
+      </VirtuosoMockContext.Provider>
+    );
   };
 
   it('should display a single series name', () => {

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
@@ -42,7 +42,7 @@ export function TooltipContent(props: TooltipContentProps): ReactElement | null 
   if (series === null || sortedFocusedSeries === null) {
     return null;
   }
-  // TODO: use react-virtuoso to improve performance
+  // LOGZ.IO CHANGE START:: Performance optimization [APPZ-359]
   return (
     <VirtualizedSeries
       allowActions={allowActions}
@@ -51,4 +51,5 @@ export function TooltipContent(props: TooltipContentProps): ReactElement | null 
       onSelected={onSelected}
     />
   );
+  // LOGZ.IO CHANGE END:: Performance optimization [APPZ-359]
 }

--- a/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipContent.tsx
@@ -12,9 +12,8 @@
 // limitations under the License.
 
 import { ReactElement, useMemo } from 'react';
-import { Box } from '@mui/material';
 import { NearbySeriesArray } from './nearby-series';
-import { SeriesInfo } from './SeriesInfo';
+import { VirtualizedSeries } from './VirtualizedSeries';
 
 export interface TooltipContentProps {
   series: NearbySeriesArray | null;
@@ -45,40 +44,11 @@ export function TooltipContent(props: TooltipContentProps): ReactElement | null 
   }
   // TODO: use react-virtuoso to improve performance
   return (
-    <Box
-      sx={(theme) => ({
-        padding: theme.spacing(0.5, 2),
-        // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
-        maxHeight: '300px',
-        overflow: 'auto',
-        borderBottom: allowActions ? `1px solid ${theme.palette.divider}` : undefined,
-        // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
-      })}
-    >
-      {sortedFocusedSeries.map(
-        ({ datumIdx, seriesIdx, seriesName, y, formattedY, markerColor, isClosestToCursor, isSelected, metadata }) => {
-          if (datumIdx === null || seriesIdx === null) return null;
-          const key = seriesIdx.toString() + datumIdx.toString();
-
-          return (
-            <SeriesInfo
-              key={key}
-              seriesName={seriesName}
-              y={y}
-              formattedY={formattedY}
-              markerColor={markerColor}
-              totalSeries={sortedFocusedSeries.length}
-              wrapLabels={wrapLabels}
-              emphasizeText={isClosestToCursor}
-              // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
-              isSelected={isSelected}
-              isSelectable={metadata?.isSelectable ?? true}
-              onSelected={onSelected ? (): void => onSelected(seriesIdx) : undefined}
-              // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
-            />
-          );
-        }
-      )}
-    </Box>
+    <VirtualizedSeries
+      allowActions={allowActions}
+      sortedFocusedSeries={sortedFocusedSeries}
+      wrapLabels={wrapLabels}
+      onSelected={onSelected}
+    />
   );
 }

--- a/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
+++ b/ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx
@@ -14,7 +14,7 @@
 import { render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
 import { TooltipHeader, TooltipHeaderProps } from './TooltipHeader';
-import { NearbySeriesArray } from './nearby-series';
+import { NearbySeriesArray } from './types';
 
 describe('TooltipHeader', () => {
   const renderComponent = (props: TooltipHeaderProps): void => {

--- a/ui/components/src/TimeSeriesTooltip/VirtualizedSeries.tsx
+++ b/ui/components/src/TimeSeriesTooltip/VirtualizedSeries.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Box } from '@mui/material';
+import { Virtuoso } from 'react-virtuoso';
+import { TooltipContentProps } from './TooltipContent';
+import { SeriesInfo } from './SeriesInfo';
+
+export interface VirtualizedSeriesProps {
+  allowActions: TooltipContentProps['allowActions'];
+  wrapLabels: TooltipContentProps['wrapLabels'];
+  onSelected?: TooltipContentProps['onSelected'];
+  sortedFocusedSeries: NonNullable<TooltipContentProps['series']>;
+}
+
+export const VirtualizedSeries: React.FC<VirtualizedSeriesProps> = ({
+  allowActions,
+  sortedFocusedSeries,
+  wrapLabels,
+  onSelected,
+}) => {
+  const [height, setHeight] = useState(10);
+  return (
+    <Box
+      sx={(theme) => ({
+        padding: theme.spacing(0.5, 2),
+        // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
+        borderBottom: allowActions ? `1px solid ${theme.palette.divider}` : undefined,
+        // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
+      })}
+    >
+      <Virtuoso
+        role="list"
+        style={{ height: height > 300 ? 300 : height, width: '100%' }}
+        totalListHeightChanged={setHeight}
+        totalCount={sortedFocusedSeries.length}
+        data={sortedFocusedSeries}
+        itemContent={(index, data) => {
+          if (!data.datumIdx || !data.seriesIdx) return null;
+
+          const key = data.seriesIdx.toString() + data.datumIdx.toString();
+
+          return (
+            <SeriesInfo
+              key={key}
+              seriesName={data.seriesName}
+              y={data.y}
+              formattedY={data.formattedY}
+              markerColor={data.markerColor}
+              totalSeries={sortedFocusedSeries.length}
+              wrapLabels={wrapLabels}
+              emphasizeText={data.isClosestToCursor}
+              // LOGZ.IO CHANGE START:: Drilldown panel [APPZ-377]
+              isSelected={data.isSelected}
+              isSelectable={data.metadata?.isSelectable ?? true}
+              onSelected={onSelected ? (): void => onSelected(data.seriesIdx!) : undefined}
+              // LOGZ.IO CHANGE END:: Drilldown panel [APPZ-377]
+            />
+          );
+        }}
+      />
+    </Box>
+  );
+};

--- a/ui/components/src/TimeSeriesTooltip/VirtualizedSeries.tsx
+++ b/ui/components/src/TimeSeriesTooltip/VirtualizedSeries.tsx
@@ -14,6 +14,7 @@
 import { useState } from 'react';
 import { Box } from '@mui/material';
 import { Virtuoso } from 'react-virtuoso';
+import { isNil } from 'lodash';
 import { TooltipContentProps } from './TooltipContent';
 import { SeriesInfo } from './SeriesInfo';
 
@@ -49,7 +50,7 @@ export const VirtualizedSeries: React.FC<VirtualizedSeriesProps> = ({
         totalCount={sortedFocusedSeries.length}
         data={sortedFocusedSeries}
         itemContent={(index, data) => {
-          if (!data.datumIdx || !data.seriesIdx) return null;
+          if (isNil(data.datumIdx) || isNil(data.seriesIdx)) return null;
 
           const key = data.seriesIdx.toString() + data.datumIdx.toString();
 

--- a/ui/components/src/TimeSeriesTooltip/VirtualizedSeries.tsx
+++ b/ui/components/src/TimeSeriesTooltip/VirtualizedSeries.tsx
@@ -1,3 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import { useState } from 'react';
 import { Box } from '@mui/material';
 import { Virtuoso } from 'react-virtuoso';
@@ -10,6 +23,8 @@ export interface VirtualizedSeriesProps {
   onSelected?: TooltipContentProps['onSelected'];
   sortedFocusedSeries: NonNullable<TooltipContentProps['series']>;
 }
+
+// LOGZ.IO CHANGE FILE:: Performance optimization [APPZ-359]
 
 export const VirtualizedSeries: React.FC<VirtualizedSeriesProps> = ({
   allowActions,

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.test.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.test.ts
@@ -87,7 +87,7 @@ describe('legacyCheckforNearbySeries', () => {
 
 describe('getYBuffer', () => {
   it('should return area to search for nearby series', () => {
-    expect(getYBuffer({ yInterval: 1, totalSeries: 10, showAllSeries: false })).toBe(3);
+    expect(getYBuffer({ yInterval: 1, totalSeries: 10, showAllSeries: false })).toBe(1);
   });
 
   it('should return entire canvas', () => {

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -146,11 +146,6 @@ export function checkforNearbyTimeSeries(
                 });
               } else {
                 nonEmphasizedSeriesIndexes.push(seriesIdx);
-                // ensure series far away from cursor are not highlighted
-                chart.dispatchAction({
-                  type: 'downplay',
-                  seriesIndex: seriesIdx,
-                });
               }
               const formattedY = formatValue(yValue, format);
               currentNearbySeriesData.push({

--- a/ui/components/src/TimeSeriesTooltip/nearby-series.ts
+++ b/ui/components/src/TimeSeriesTooltip/nearby-series.ts
@@ -146,6 +146,11 @@ export function checkforNearbyTimeSeries(
                 });
               } else {
                 nonEmphasizedSeriesIndexes.push(seriesIdx);
+                // ensure series far away from cursor are not highlighted
+                chart.dispatchAction({
+                  type: 'downplay',
+                  seriesIndex: seriesIdx,
+                });
               }
               const formattedY = formatValue(yValue, format);
               currentNearbySeriesData.push({

--- a/ui/core/src/model/base-metadata.ts
+++ b/ui/core/src/model/base-metadata.ts
@@ -1,0 +1,31 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Notice } from './notice';
+
+export interface BaseMetadata {
+  /**
+   * A list of notices to display in the panel.
+   * These notices are passed down to the panel header
+   * and can be used to inform the user about important
+   * states, warnings, or messages related to the panel’s data or configuration.
+   */
+  notices?: Notice[];
+
+  /**
+   * The raw query that is executed to generate this data.
+   * Useful when needing to inspect the query that was executed
+   * after variables and other context modifications have been applied.
+   */
+  executedQueryString?: string;
+}

--- a/ui/core/src/model/time-series-data.ts
+++ b/ui/core/src/model/time-series-data.ts
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Notice } from './notice';
+import { BaseMetadata } from './base-metadata';
 import { AbsoluteTimeRange } from './time';
 import { Labels, TimeSeriesValueTuple, TimeSeriesHistogramTuple } from './time-series-queries';
 
@@ -37,16 +37,7 @@ export interface TimeSeries {
   labels?: Labels;
 }
 
-export interface TimeSeriesMetadata {
-  notices?: Notice[];
-
-  /**
-   * The raw query that is executed to generate this data.
-   * Useful when needing to inspect the query that was executed
-   * after variables and other context modifications have been applied.
-   */
-  executedQueryString?: string;
-
+export interface TimeSeriesMetadata extends BaseMetadata {
   /**
    * Defines if the series is selectable for tooltip actions
    *

--- a/ui/core/src/model/trace-data.ts
+++ b/ui/core/src/model/trace-data.ts
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { BaseMetadata } from './base-metadata';
 import { TracesData } from './otlp/trace/v1/trace';
 
 /**
@@ -42,11 +43,7 @@ export interface TraceData {
   trace?: TracesData;
   searchResult?: TraceSearchResult[];
 
-  metadata?: TraceMetaData;
-}
-
-export interface TraceMetaData {
-  executedQueryString?: string;
+  metadata?: BaseMetadata;
 }
 
 export function isValidTraceId(traceId: string): boolean {

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -14,7 +14,7 @@
 import { Box } from '@mui/material';
 import { useInView } from 'react-intersection-observer';
 import { DataQueriesProvider, usePlugin, useSuggestedStepMs } from '@perses-dev/plugin-system';
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import { PanelGroupItemId, useEditMode, usePanel, usePanelActions, useViewPanelGroup } from '../../context';
 import { Panel, PanelProps, PanelOptions } from '../Panel';
 import { isPanelGroupItemIdEqual } from '../../context/DashboardProvider/panel-group-slice';
@@ -32,7 +32,7 @@ export function GridItemContent(props: GridItemContentProps): ReactElement {
   const { panelGroupItemId, width } = props;
   const panelDefinition = usePanel(panelGroupItemId);
   const {
-    spec: { queries },
+    spec: { queries = [] },
   } = panelDefinition;
   const { isEditMode } = useEditMode();
   const { openEditPanel, openDeletePanelDialog, duplicatePanel, viewPanel } = usePanelActions(panelGroupItemId);
@@ -69,18 +69,24 @@ export function GridItemContent(props: GridItemContentProps): ReactElement {
 
   const { data: plugin } = usePlugin('Panel', panelDefinition.spec.plugin.kind);
 
-  const queryDefinitions = queries ?? [];
-  const definitions = queryDefinitions.map((query) => {
-    return {
-      kind: query.spec.plugin.kind,
-      spec: query.spec.plugin.spec,
-    };
-  });
-  const pluginQueryOptions =
-    typeof plugin?.queryOptions === 'function'
-      ? plugin?.queryOptions(panelDefinition.spec.plugin.spec)
-      : plugin?.queryOptions;
+  const definitions = useMemo(
+    () =>
+      queries.map((query) => {
+        return {
+          kind: query.spec.plugin.kind,
+          spec: query.spec.plugin.spec,
+        };
+      }),
+    [queries]
+  );
 
+  const pluginQueryOptions = useMemo(
+    () =>
+      typeof plugin?.queryOptions === 'function'
+        ? plugin?.queryOptions(panelDefinition.spec.plugin.spec)
+        : plugin?.queryOptions,
+    [plugin, panelDefinition.spec.plugin.spec]
+  );
   return (
     <Box
       ref={ref}

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -258,7 +258,7 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           {descriptionAction} {linksAction}
         </OnHover>
         {divider} {queryStateIndicator}
-        {divider} {noticesIndicator}
+        {noticesIndicator}
         <OnHover>
           {extraActions} {readActions}
           <OverflowMenu title={title}>{editActions}</OverflowMenu>
@@ -278,7 +278,7 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           {descriptionAction} {linksAction}
         </OnHover>
         {divider} {queryStateIndicator}
-        {divider} {noticesIndicator}
+        {noticesIndicator}
         <OnHover>
           {extraActions} {readActions} {editActions} {moveAction}
         </OnHover>

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -23,6 +23,7 @@ import ContentCopyIcon from 'mdi-material-ui/ContentCopy';
 import MenuIcon from 'mdi-material-ui/Menu';
 import { QueryData } from '@perses-dev/plugin-system';
 import AlertIcon from 'mdi-material-ui/Alert';
+import AlertCircleIcon from 'mdi-material-ui/AlertCircle';
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
 import { Link } from '@perses-dev/core';
 import {
@@ -108,6 +109,30 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         <InfoTooltip description={errorTexts}>
           <HeaderIconButton aria-label="panel errors" size="small">
             <AlertIcon fontSize="inherit" />
+          </HeaderIconButton>
+        </InfoTooltip>
+      );
+    }
+  }, [queryResults]);
+
+  const noticesIndicator = useMemo(() => {
+    const notices = queryResults.flatMap((q) => {
+      return q.data?.metadata?.notices ?? [];
+    });
+
+    if (notices.length > 0) {
+      const lastNotice = notices[notices.length - 1]!;
+
+      return (
+        <InfoTooltip description={lastNotice.message}>
+          <HeaderIconButton aria-label="panel notices" size="small">
+            {lastNotice.type === 'warning' ? (
+              <AlertIcon fontSize="inherit" color="warning" />
+            ) : lastNotice.type === 'info' ? (
+              <InformationOutlineIcon fontSize="inherit" color="info" />
+            ) : (
+              <AlertCircleIcon color="error" />
+            )}
           </HeaderIconButton>
         </InfoTooltip>
       );
@@ -214,7 +239,8 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
         {divider}
         <OnHover>
           <OverflowMenu title={title}>
-            {descriptionAction} {linksAction} {queryStateIndicator} {extraActions} {readActions} {editActions}
+            {descriptionAction} {linksAction} {queryStateIndicator} {noticesIndicator} {extraActions} {readActions}{' '}
+            {editActions}
           </OverflowMenu>
           {moveAction}
         </OnHover>
@@ -232,6 +258,7 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           {descriptionAction} {linksAction}
         </OnHover>
         {divider} {queryStateIndicator}
+        {divider} {noticesIndicator}
         <OnHover>
           {extraActions} {readActions}
           <OverflowMenu title={title}>{editActions}</OverflowMenu>
@@ -251,6 +278,7 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           {descriptionAction} {linksAction}
         </OnHover>
         {divider} {queryStateIndicator}
+        {divider} {noticesIndicator}
         <OnHover>
           {extraActions} {readActions} {editActions} {moveAction}
         </OnHover>

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -25,7 +25,7 @@ import { QueryData } from '@perses-dev/plugin-system';
 import AlertIcon from 'mdi-material-ui/Alert';
 import AlertCircleIcon from 'mdi-material-ui/AlertCircle';
 import InformationOutlineIcon from 'mdi-material-ui/InformationOutline';
-import { Link } from '@perses-dev/core';
+import { Link, Notice } from '@perses-dev/core';
 import {
   ARIA_LABEL_TEXT,
   HEADER_ACTIONS_CONTAINER_NAME,
@@ -35,6 +35,14 @@ import {
 } from '../../constants';
 import { HeaderIconButton } from './HeaderIconButton';
 import { PanelLinks } from './PanelLinks';
+
+// LOGZ.IO CHANGE START:: Performance optimization [APPZ-359]
+const noticeTypeToIcon: Record<Notice['type'], ReactNode> = {
+  error: <AlertCircleIcon color="error" />,
+  warning: <AlertIcon fontSize="inherit" color="warning" />,
+  info: <InformationOutlineIcon fontSize="inherit" color="info" />,
+};
+// LOGZ.IO CHANGE END:: Performance optimization [APPZ-359]
 
 export interface PanelActionsProps {
   title: string;
@@ -115,6 +123,7 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
     }
   }, [queryResults]);
 
+  // LOGZ.IO CHANGE START:: Performance optimization [APPZ-359]
   const noticesIndicator = useMemo(() => {
     const notices = queryResults.flatMap((q) => {
       return q.data?.metadata?.notices ?? [];
@@ -126,18 +135,13 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
       return (
         <InfoTooltip description={lastNotice.message}>
           <HeaderIconButton aria-label="panel notices" size="small">
-            {lastNotice.type === 'warning' ? (
-              <AlertIcon fontSize="inherit" color="warning" />
-            ) : lastNotice.type === 'info' ? (
-              <InformationOutlineIcon fontSize="inherit" color="info" />
-            ) : (
-              <AlertCircleIcon color="error" />
-            )}
+            {noticeTypeToIcon[lastNotice.type]}
           </HeaderIconButton>
         </InfoTooltip>
       );
     }
   }, [queryResults]);
+  // LOGZ.IO CHANGE END:: Performance optimization [APPZ-359]
 
   const readActions = useMemo(() => {
     if (readHandlers !== undefined) {

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -13,7 +13,7 @@
 
 import { usePlugin, PanelProps, QueryData, PanelPlugin } from '@perses-dev/plugin-system';
 import { UnknownSpec, PanelDefinition, QueryDataType } from '@perses-dev/core';
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
 import { LoadingOverlay } from '@perses-dev/components';
 import { Skeleton } from '@mui/material';
 import { PanelPluginLoader } from './PanelPluginLoader';
@@ -32,6 +32,13 @@ export function PanelContent(props: PanelContentProps): ReactElement {
   const { panelPluginKind, definition, queryResults, spec, contentDimensions } = props;
   const { data: plugin, isLoading: isPanelLoading } = usePlugin('Panel', panelPluginKind, { throwOnError: true });
 
+  // Render the panel if any query has data, or the panel doesn't have a query attached (for example MarkdownPanel).
+  // Loading indicator or errors of other queries are shown in the panel header.
+  const queryResultsWithData = useMemo(
+    () => queryResults.flatMap((q) => (q.data ? [{ data: q.data, definition: q.definition }] : [])),
+    [queryResults]
+  );
+
   // Show fullsize skeleton if the panel plugin is loading.
   if (isPanelLoading) {
     return (
@@ -44,11 +51,6 @@ export function PanelContent(props: PanelContentProps): ReactElement {
     );
   }
 
-  // Render the panel if any query has data, or the panel doesn't have a query attached (for example MarkdownPanel).
-  // Loading indicator or errors of other queries are shown in the panel header.
-  const queryResultsWithData = queryResults.flatMap((q) =>
-    q.data ? [{ data: q.data, definition: q.definition }] : []
-  );
   if (queryResultsWithData.length > 0 || queryResults.length === 0) {
     return (
       <PanelPluginLoader

--- a/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelPreview.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ReactElement, useRef } from 'react';
+import { ReactElement, useMemo, useRef } from 'react';
 import { Box } from '@mui/material';
 import { DataQueriesProvider, usePlugin, useSuggestedStepMs } from '@perses-dev/plugin-system';
 import { PanelEditorValues } from '@perses-dev/core';
@@ -22,6 +22,21 @@ const PANEL_PREVIEW_DEFAULT_WIDTH = 840;
 
 export function PanelPreview({ panelDefinition }: Pick<PanelEditorValues, 'panelDefinition'>): ReactElement | null {
   const boxRef = useRef<HTMLDivElement>(null);
+
+  // map TimeSeriesQueryDefinition to Definition<UnknownSpec>
+  const definitions = useMemo(() => {
+    const queries = panelDefinition.spec.queries ?? [];
+
+    return queries.length
+      ? queries.map((query) => {
+          return {
+            kind: query.spec.plugin.kind,
+            spec: query.spec.plugin.spec,
+          };
+        })
+      : [];
+  }, [panelDefinition.spec.queries]);
+
   let width = PANEL_PREVIEW_DEFAULT_WIDTH;
   if (boxRef.current !== null) {
     width = boxRef.current.getBoundingClientRect().width;
@@ -36,18 +51,6 @@ export function PanelPreview({ panelDefinition }: Pick<PanelEditorValues, 'panel
   if (panelDefinition.spec.plugin.kind === '') {
     return null;
   }
-
-  const queries = panelDefinition.spec.queries ?? [];
-
-  // map TimeSeriesQueryDefinition to Definition<UnknownSpec>
-  const definitions = queries.length
-    ? queries.map((query) => {
-        return {
-          kind: query.spec.plugin.kind,
-          spec: query.spec.plugin.spec,
-        };
-      })
-    : [];
 
   return (
     <Box ref={boxRef} height={PANEL_PREVIEW_HEIGHT}>

--- a/ui/plugin-system/src/hooks/array-memo.ts
+++ b/ui/plugin-system/src/hooks/array-memo.ts
@@ -1,0 +1,35 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useRef } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const useArrayMemo = <T extends any[]>(array: T): T => {
+  const ref = useRef<T>();
+
+  const isSame =
+    ref.current && array.length === ref.current.length
+      ? array.every((entry, i) => {
+          const prevEntry = ref.current![i];
+          const values = Object.values(entry);
+          const prevValues = Object.values(prevEntry);
+          return values.length === prevValues.length && values.every((v, vi) => v === prevValues[vi]);
+        })
+      : false;
+
+  useEffect(() => {
+    if (!isSame) ref.current = array;
+  }, [isSame, array]);
+
+  return isSame ? ref.current! : array;
+};

--- a/ui/plugin-system/src/hooks/array-memo.ts
+++ b/ui/plugin-system/src/hooks/array-memo.ts
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// LOGZ.IO CHANGE FILE:: Performance optimization [APPZ-359]
+
 import { useEffect, useRef } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/plugin-system/src/hooks/index.ts
+++ b/ui/plugin-system/src/hooks/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from './array-memo';
+export * from './stable-queries';

--- a/ui/plugin-system/src/hooks/index.ts
+++ b/ui/plugin-system/src/hooks/index.ts
@@ -11,5 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// LOGZ.IO CHANGE FILE:: Performance optimization [APPZ-359]
+
 export * from './array-memo';
 export * from './stable-queries';

--- a/ui/plugin-system/src/hooks/stable-queries.ts
+++ b/ui/plugin-system/src/hooks/stable-queries.ts
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// LOGZ.IO CHANGE FILE:: Performance optimization [APPZ-359]
+
 import { useQueries } from '@tanstack/react-query';
 import { useArrayMemo } from './array-memo';
 

--- a/ui/plugin-system/src/hooks/stable-queries.ts
+++ b/ui/plugin-system/src/hooks/stable-queries.ts
@@ -1,0 +1,34 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useQueries } from '@tanstack/react-query';
+import { useArrayMemo } from './array-memo';
+
+/**
+ * Creates a stable reference of the `useQueries` response.
+ *
+ * This is useful because `useQueries` returns a new array on every render,
+ * which can trigger unnecessary re-renders or effect executions in components
+ * that depend on it. By stabilizing the reference with `useArrayMemo`,
+ * this hook ensures that downstream components only update when the actual
+ * query results change, improving performance and preventing redundant updates.
+ */
+export function useStableQueries<T extends unknown[], TCombinedResult = ReturnType<typeof useQueries<T>>>(
+  opts: Parameters<typeof useQueries<T>>[0]
+): TCombinedResult {
+  const results = useQueries<T>(opts);
+
+  const stableResults = useArrayMemo(results);
+
+  return stableResults as unknown as TCombinedResult;
+}

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -13,7 +13,6 @@
 
 import {
   useQuery,
-  useQueries,
   useQueryClient,
   Query,
   QueryCache,
@@ -23,6 +22,7 @@ import {
 } from '@tanstack/react-query';
 import { TimeSeriesQueryDefinition, UnknownSpec, TimeSeriesData } from '@perses-dev/core';
 import { TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryMode, TimeSeriesQueryPlugin } from '../model';
+import { useStableQueries } from '../hooks';
 import { useAllVariableValues } from './variables';
 import { useTimeRange } from './TimeRangeProvider';
 import { useDatasourceStore } from './datasources';
@@ -127,7 +127,7 @@ export function useTimeSeriesQueries(
     definitions.map((d) => ({ kind: d.spec.plugin.kind }))
   );
 
-  return useQueries({
+  return useStableQueries({
     queries: definitions.map((definition, idx) => {
       const plugin = pluginLoaderResponse[idx]?.data;
       const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
@@ -142,6 +142,7 @@ export function useTimeSeriesQueries(
           };
           const plugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
           const data = await plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx);
+
           return data;
         },
       };

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -127,6 +127,7 @@ export function useTimeSeriesQueries(
     definitions.map((d) => ({ kind: d.spec.plugin.kind }))
   );
 
+  // LOGZ.IO CHANGE:: Performance optimization [APPZ-359] useStableQueries()
   return useStableQueries({
     queries: definitions.map((definition, idx) => {
       const plugin = pluginLoaderResponse[idx]?.data;

--- a/ui/plugin-system/src/runtime/trace-queries.tsx
+++ b/ui/plugin-system/src/runtime/trace-queries.tsx
@@ -37,9 +37,7 @@ export function getUnixTimeRange(timeRange: AbsoluteTimeRange): { start: number;
  * @param definitions: dashboard defintion for a trace query, written in Trace Query Language (TraceQL)
  * Documentation for TraceQL: https://grafana.com/docs/tempo/latest/traceql/
  */
-export function useTraceQueries(
-  definitions: TraceQueryDefinition[]
-): Array<UseQueryResult<TraceData & { isSliced: boolean }>> {
+export function useTraceQueries(definitions: TraceQueryDefinition[]): Array<UseQueryResult<TraceData>> {
   const { getPlugin } = usePluginRegistry();
   const context = useTraceQueryContext();
 
@@ -59,10 +57,10 @@ export function useTraceQueries(
       return {
         enabled: queryEnabled,
         queryKey: queryKey,
-        queryFn: async (): Promise<TraceData & { isSliced: boolean }> => {
+        queryFn: async (): Promise<TraceData> => {
           const plugin = await getPlugin(TRACE_QUERY_KEY, traceQueryKind);
           const data = await plugin.getTraceData(definition.spec.plugin.spec, context);
-          return { ...data, isSliced: false };
+          return data;
         },
       };
     }),

--- a/ui/plugin-system/src/runtime/trace-queries.tsx
+++ b/ui/plugin-system/src/runtime/trace-queries.tsx
@@ -50,6 +50,7 @@ export function useTraceQueries(
 
   // useQueries() handles data fetching from query plugins (e.g. traceQL queries, promQL queries)
   // https://tanstack.com/query/v4/docs/react/reference/useQuery
+  // LOGZ.IO CHANGE:: Performance optimization [APPZ-359] useStableQueries()
   return useStableQueries({
     queries: definitions.map((definition, idx) => {
       const plugin = pluginLoaderResponse[idx]?.data;


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
In perses we don't have a way to show indication for the user incase his data was manipulated (such as he gave us thousands of series).
For that I rode an already existing property called `notices`, that will be displayed for the user in the panel itself.

<!-- Context useful to a reviewer -->

# Screenshots
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/a9c6e781-294d-4d79-a010-bce7fe395e8b" />

<!-- If there are UI changes -->

# Checklist

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [X] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Surfaces query notices in panel headers while improving chart performance via virtualized tooltip lists, ResizeObserver-based resizing, stable query arrays, and broader memoization.
> 
> - **Core Model**:
>   - Add `BaseMetadata` with `notices` and `executedQueryString`; adopt in `TimeSeriesMetadata` and `TraceData`.
> - **Dashboards UI**:
>   - Panel header shows metadata notices (`PanelActions`) with contextual icons; integrates with tooltip.
>   - Memoize queries/options in `GridItemContent`, `PanelContent`, and `PanelPreview`.
> - **Charts/Components**:
>   - `EChart` uses `ResizeObserver` + `requestAnimationFrame` for responsive resizing.
>   - Virtualize tooltip series: replace inline map with `VirtualizedSeries` (`react-virtuoso`), update tests with `VirtuosoMockContext`.
>   - Minor: shared `SX` for full-size charts in `LineChart`/`TimeChart`.
> - **Plugin System**:
>   - New hooks: `useArrayMemo`, `useStableQueries`; applied to time-series and trace queries to stabilize results.
>   - Memoize filtering and query definitions in `DataQueriesProvider`; memoize `useUsageMetrics.markQuery`.
> - **Tests**:
>   - Update `nearby-series` expectations for `getYBuffer` and add interval coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fb81ee813fee0b236022bb1da8922c158b1b18f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->