### PR TITLE
Fix stacked bar chart tooltip

### DIFF
--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -240,10 +240,9 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
       tooltip: {
         show: true,
         // ECharts tooltip content hidden by default since we use custom tooltip instead.
-        // Stacked bar uses ECharts tooltip so subgroup data shows correctly.
-        showContent: isStackedBar,
-        trigger: isStackedBar ? 'item' : 'axis',
-        appendToBody: isStackedBar,
+        showContent: false,
+        trigger: 'axis',
+        appendToBody: false,
       },
       // https://echarts.apache.org/en/option.html#axisPointer
       axisPointer: {
@@ -280,7 +279,6 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
     __experimentalEChartsOptionsOverride,
     noDataVariant,
     timeZone,
-    isStackedBar,
     enablePinning,
     pinnedCrosshair,
   ]);

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -239,10 +239,12 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
       animation: false,
       tooltip: {
         show: true,
+        // LOGZ.IO CHANGE START:: Calculate stacked bar [APPZ-1418]
         // ECharts tooltip content hidden by default since we use custom tooltip instead.
         showContent: false,
         trigger: 'axis',
         appendToBody: false,
+        // LOGZ.IO CHANGE END:: Calculate stacked bar [APPZ-1418]
       },
       // https://echarts.apache.org/en/option.html#axisPointer
       axisPointer: {

--- a/ui/components/src/TimeChart/TimeChart.tsx
+++ b/ui/components/src/TimeChart/TimeChart.tsx
@@ -85,7 +85,6 @@ export interface TimeChartProps {
   tooltipConfig?: TooltipConfig;
   noDataVariant?: 'chart' | 'message';
   syncGroup?: string;
-  isStackedBar?: boolean;
   onDataZoom?: (e: ZoomEventData) => void;
   onDoubleClick?: (e: MouseEvent) => void;
   __experimentalEChartsOptionsOverride?: (options: EChartsCoreOption) => EChartsCoreOption;
@@ -101,7 +100,6 @@ export const TimeChart = forwardRef<ChartInstance, TimeChartProps>(function Time
     yAxis,
     format,
     grid,
-    isStackedBar = false,
     tooltipConfig = DEFAULT_TOOLTIP_CONFIG,
     noDataVariant = 'message',
     syncGroup,

--- a/ui/components/src/TimeSeriesTooltip/types.ts
+++ b/ui/components/src/TimeSeriesTooltip/types.ts
@@ -36,6 +36,7 @@ export type Candidate = Omit<NearbySeriesInfo, 'isClosestToCursor' | 'seriesIdx'
   visualY: number;
   distance: number;
   isSelected: boolean;
+  isStacked?: boolean;
 };
 
 export type CalculateVisualYForSeriesParams = {
@@ -57,6 +58,7 @@ export type CalculateBarSegmentBoundsParams = {
   bandwidth: number;
   seriesIdx: number;
   barSeriesOrder: number[];
+  isStacked: boolean;
 };
 
 export type BarSegmentBounds = {

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -36,6 +36,14 @@ import {
   NearbySeriesArray,
 } from './types';
 
+function isBarSeriesOption(series: LineSeriesOption | BarSeriesOption): series is BarSeriesOption {
+  return series.type === 'bar';
+}
+
+function isLineSeriesOption(series: LineSeriesOption | BarSeriesOption): series is LineSeriesOption {
+  return series.type === 'line' || series.type === undefined;
+}
+
 /**
  * Determine position of tooltip depending on chart dimensions and the number of focused series
  */
@@ -284,7 +292,11 @@ export function createBarGroupCandidates({
               distance = Infinity;
             }
 
-            const stackId = (currentSeries as LineSeriesOption | BarSeriesOption).stack;
+            let stackId: string | undefined;
+            if (isBarSeriesOption(currentSeries)) {
+              stackId = currentSeries.stack;
+            }
+
             const visualY = calculateVisualYForSeries({
               rawY: yValue,
               stackId,
@@ -433,7 +445,11 @@ export function gatherCandidates({
             }
 
             if (seriesType === 'line') {
-              const stackId = (currentSeries as LineSeriesOption).stack;
+              let stackId: string | undefined;
+              if (isLineSeriesOption(currentSeries)) {
+                stackId = currentSeries.stack;
+              }
+
               const visualY = calculateVisualYForSeries({
                 rawY: yValue,
                 stackId,
@@ -497,8 +513,13 @@ export function gatherCandidates({
                   chart,
                 });
 
-                const stackId = (currentSeries as BarSeriesOption).stack;
-                const isStackedBar = stackId !== undefined;
+                let stackId: string | undefined;
+                let isStackedBar = false;
+
+                if (isBarSeriesOption(currentSeries)) {
+                  stackId = currentSeries.stack;
+                  isStackedBar = stackId !== undefined;
+                }
 
                 const { segLeft, segRight } = calculateBarSegmentBounds({
                   timestampCenterX,
@@ -513,7 +534,7 @@ export function gatherCandidates({
                 if (isWithinXBounds) {
                   let isHoveringYBounds = true;
 
-                  if (isStackedBar) {
+                  if (isStackedBar && stackId !== undefined) {
                     const visualY = calculateVisualYForSeries({ rawY: yValue, stackId, stackTotals });
                     const { lower, upper } = calculateBarYBounds({
                       visualY,

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -245,8 +245,6 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           <OverflowMenu title={title}>
             {descriptionAction} {linksAction} {queryStateIndicator} {noticesIndicator} {extraActions} {readActions}{' '}
             {editActions}
-            {descriptionAction} {linksAction} {queryStateIndicator} {noticesIndicator} {extraActions} {readActions}{' '}
-            {editActions}
           </OverflowMenu>
           {moveAction}
         </OnHover>

--- a/ui/dashboards/src/components/Panel/PanelActions.tsx
+++ b/ui/dashboards/src/components/Panel/PanelActions.tsx
@@ -245,6 +245,8 @@ export const PanelActions: React.FC<PanelActionsProps> = ({
           <OverflowMenu title={title}>
             {descriptionAction} {linksAction} {queryStateIndicator} {noticesIndicator} {extraActions} {readActions}{' '}
             {editActions}
+            {descriptionAction} {linksAction} {queryStateIndicator} {noticesIndicator} {extraActions} {readActions}{' '}
+            {editActions}
           </OverflowMenu>
           {moveAction}
         </OnHover>


### PR DESCRIPTION
## Fix: Stacked Bar Chart Tooltip Positioning and Value Display

### Problem
Custom tooltip for stacked bar charts had two critical bugs:
1. **Positioning**: Tooltip appeared ~1px left of the correct bar position
2. **Values**: Displayed raw values instead of cumulative stacked values

### Solution

![StackedBarFix](https://github.com/user-attachments/assets/e3643889-d872-4f00-8d58-2930a490708a)

**1. X-Axis Positioning Fix**
- Updated `calculateBarSegmentBounds` to treat stacked bars correctly
- Stacked bars now use full bandwidth at same X position (overlapping vertically)
- Grouped bars continue to use divided segments

**2. Stacked Value Display Fix**
- Added `isStacked` flag to `Candidate` type to track stacking state
- Modified `processCandidates` to format `visualY` (cumulative) for stacked series instead of raw `y` values
- Non-stacked series continue to show raw values

### Files Changed
- `ui/components/src/TimeSeriesTooltip/types.ts` - Added `isStacked` properties
- `ui/components/src/TimeSeriesTooltip/utils.ts` - Fixed positioning and value calculation
- `ui/components/src/TimeSeriesTooltip/TooltipHeader.test.tsx` - Fixed import


## gaia-hermes required change

**For this to work we need to allow stacked bar chart to pin the tooltip.**

<img width="1830" height="390" alt="image" src="https://github.com/user-attachments/assets/72b36a54-fc0f-46a4-bcf8-1bf750b8b0b2" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes stacked bar tooltip to align over the correct bar segment and display cumulative stacked values, while standardizing tooltip behavior and removing an unused prop.
> 
> - **TimeSeriesTooltip**:
>   - Add `isStacked` to `Candidate` and compute `visualY` per stack; format cumulative values for stacked series and use `valueToFormat` in payloads.
>   - Treat stacked bars as full-bandwidth segments in `calculateBarSegmentBounds`; refine `calculateBarYBounds`.
>   - Add type guards for series options; correctly detect `stack` for line/bar series; update candidate gathering for bars and lines.
> - **TimeChart**:
>   - Standardize ECharts tooltip to custom usage (`showContent: false`, `trigger: 'axis'`, `appendToBody: false`).
>   - Remove `isStackedBar` prop and related logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c355324a07b3b0eef121f89095f0fbd7ab4b0081. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->