### PR TITLE
Fix tooltip value on stacked points

### DIFF
--- a/ui/components/src/TimeSeriesTooltip/types.ts
+++ b/ui/components/src/TimeSeriesTooltip/types.ts
@@ -36,7 +36,6 @@ export type Candidate = Omit<NearbySeriesInfo, 'isClosestToCursor' | 'seriesIdx'
   visualY: number;
   distance: number;
   isSelected: boolean;
-  isStacked?: boolean;
 };
 
 export type CalculateVisualYForSeriesParams = {

--- a/ui/components/src/TimeSeriesTooltip/utils.ts
+++ b/ui/components/src/TimeSeriesTooltip/utils.ts
@@ -332,7 +332,6 @@ export function createBarGroupCandidates({
               distance,
               isSelected,
               metadata: currentMetadata,
-              isStacked: stackId !== undefined,
             });
           }
         }
@@ -477,7 +476,6 @@ export function gatherCandidates({
                   distance: verticalDistance,
                   isSelected,
                   metadata: currentMetadata,
-                  isStacked: stackId !== undefined,
                 });
               }
             } else if (seriesType === 'bar') {
@@ -603,7 +601,7 @@ export function processCandidates(
 
   for (const candidate of candidates) {
     const isClosestToCursor = candidate === winner;
-    const valueToFormat = candidate.isStacked ? candidate.visualY : candidate.y;
+    const valueToFormat = candidate.y;
     const formattedY = formatValue(valueToFormat, format);
 
     if (isClosestToCursor) {

--- a/ui/components/src/model/graph.ts
+++ b/ui/components/src/model/graph.ts
@@ -76,7 +76,11 @@ export const PINNED_CROSSHAIR_SERIES_NAME = 'Pinned Crosshair';
 export const DEFAULT_PINNED_CROSSHAIR: LineSeriesOption = {
   name: PINNED_CROSSHAIR_SERIES_NAME,
   type: 'line',
-  // https://echarts.apache.org/en/option.html#series-line.markLine
+  data: [],
+  showSymbol: false,
+  lineStyle: {
+    opacity: 0,
+  },
   markLine: {
     data: [],
     lineStyle: {


### PR DESCRIPTION
## Fix: Stacked Series Tooltip Issues

### Issues Fixed

**1. Incorrect Values in Stacked Series Tooltips**
- Tooltips displayed cumulative values instead of raw values
- Example: Series B (raw: 20, stacked on A: 10) showed **30** instead of **20**

**2. Crosshair Artifacts After Unpinning**
- Clicking to unpin tooltip left checkered line artifacts on chart
- Multiple clicks created multiple artifact lines

**3. Unwanted Line Through First Series When Pinned**
- Pinning tooltip caused a line to render through the first series
- Line appeared regardless of which series was clicked

### Root Causes

**Issue 1:** `processCandidates` conditionally formatted `visualY` for stacked series instead of always using raw `y` values.

**Issue 2:** State update race condition in onClick handler - `setPinnedCrosshair` was called twice, recreating the crosshair immediately after clearing it.

**Issue 3:** `DEFAULT_PINNED_CROSSHAIR` lacked explicit `data: []`, causing ECharts to default to `datasetIndex: 0`.

### Solution

**Fix 1: Display Raw Values**
- Updated `processCandidates` to always format `candidate.y` (raw value)
- Removed unused `isStacked` property from `Candidate` type
- Preserved `visualY` calculation for positioning and hover detection

**Fix 2: Prevent Crosshair Artifacts**
- Simplified onClick handler with deterministic pin/unpin logic
- Removed nested setState callbacks
- Early return pattern prevents state update race conditions

**Fix 3: Hide Line Series Data**
- Added `data: []` to `DEFAULT_PINNED_CROSSHAIR` to prevent dataset binding
- Added `showSymbol: false` and `lineStyle: { opacity: 0 }` for safety
- Only the markLine (vertical dashed crosshair) renders

![StackedTooltipValueFix](https://github.com/user-attachments/assets/ecb67364-7cc5-47c4-af8f-1430af98935c)