### PR TITLE
APPZ-1655 - Plugin editor bug fix logzio

### DIFF
--- a/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
+++ b/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
@@ -121,7 +121,7 @@ export function usePluginEditor(props: UsePluginEditorProps): {
     if (!pendingSelection) return;
 
     // Can't get spec value until we have a plugin
-    if (plugin === undefined) return;
+    if (plugin === undefined || isFetching) return;
 
     // Fire an onChange to change to the pending kind with initial values from the plugin
     rememberCurrentSpecState();
@@ -138,7 +138,16 @@ export function usePluginEditor(props: UsePluginEditorProps): {
       }
     }
     setPendingSelection(undefined);
-  }, [pendingSelection, plugin, rememberCurrentSpecState, onChange, onHideQuery, hideQueryState, value.selection]);
+  }, [
+    pendingSelection,
+    plugin,
+    isFetching,
+    rememberCurrentSpecState,
+    onChange,
+    onHideQuery,
+    hideQueryState,
+    value.selection,
+  ]);
 
   /**
    * When the user tries to change the plugin kind, make sure we have the correct spec for that plugin kind before we


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
https://github.com/perses/perses/pull/3613

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> PluginEditor now waits for plugin fetch to complete before applying pending selection and initializing spec/hide-query state.
> 
> - **Plugin Editor (`plugin-editor-api.ts`)**:
>   - Gate pending selection effect on `isFetching` to wait for plugin load before initializing `spec` and hide-query state.
>   - Add `isFetching` to the effect dependency array to sync with loading state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ab4065fdd8b5b0435c7d62b1df8c32736fe4f45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->