### PR TITLE
Fix VariableEditorForm to use the correct values of StaticListVariable

### DIFF
--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -13,7 +13,7 @@
 
 import { DispatchWithoutAction, ReactElement, useCallback, useState } from 'react';
 import { Box, Typography, Switch, TextField, Grid, FormControlLabel, MenuItem, Stack, Divider } from '@mui/material';
-import { VariableDefinition, ListVariableDefinition, Action } from '@perses-dev/core';
+import { VariableDefinition, ListVariableDefinition, Action, pluginSchema } from '@perses-dev/core';
 import { DiscardChangesConfirmationDialog, ErrorAlert, ErrorBoundary, FormActions } from '@perses-dev/components';
 import { Control, Controller, FormProvider, SubmitHandler, useForm, useFormContext, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -24,6 +24,15 @@ import { useValidationSchemas } from '../../../context';
 import { VARIABLE_TYPES } from '../variable-model';
 import { VariableListPreview, VariablePreview } from './VariablePreview';
 import { SORT_METHODS, SortMethodName } from './variable-editor-form-model';
+
+// LOGZ.IO CHANGE START:: Upgrade perses to latest [APPZ-1597]
+const DEFAULT_LIST_VARIABLE_PLUGIN = pluginSchema.parse({
+  kind: 'StaticListVariable' as const,
+  spec: {
+    values: [],
+  },
+});
+// LOGZ.IO CHANGE END:: Upgrade perses to latest [APPZ-1597]
 
 function FallbackPreview(): ReactElement {
   return <div>Error previewing values</div>;
@@ -131,7 +140,7 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
   }
 
   if (!values.spec.plugin) {
-    form.setValue('spec.plugin', { kind: 'StaticListVariable', spec: {} });
+    form.setValue('spec.plugin', DEFAULT_LIST_VARIABLE_PLUGIN); // LOGZ.IO CHANGE:: Upgrade perses to latest [APPZ-1597]
   }
 
   if (!values.spec.sort) {
@@ -164,9 +173,9 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
                     value={{
                       selection: {
                         type: 'Variable',
-                        kind: kind ?? 'StaticListVariable',
+                        kind: kind ?? DEFAULT_LIST_VARIABLE_PLUGIN.kind, // LOGZ.IO CHANGE:: Upgrade perses to latest [APPZ-1597]
                       },
-                      spec: pluginSpec ?? {},
+                      spec: pluginSpec ?? DEFAULT_LIST_VARIABLE_PLUGIN.spec, // LOGZ.IO CHANGE:: Upgrade perses to latest [APPZ-1597]
                     }}
                     isReadonly={action === 'read'}
                     onChange={(v) => {


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
bugfix

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize `ListVariable` plugin with schema-validated `StaticListVariable` defaults and use them in `PluginEditor` and form initialization.
> 
> - **Variables UI** (`ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx`):
>   - Add `pluginSchema` import and define `DEFAULT_LIST_VARIABLE_PLUGIN` parsed as `StaticListVariable` with empty `values`.
>   - Use `DEFAULT_LIST_VARIABLE_PLUGIN` when initializing `spec.plugin` for `ListVariable`.
>   - Update `PluginEditor` default `selection.kind` and `spec` to use `DEFAULT_LIST_VARIABLE_PLUGIN`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bffb0d715b638bb3725e89e96f0858cd24e95a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->