### PR TITLE
Randomuuid

### DIFF
--- a/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/duplicate-panel-slice.ts
@@ -13,7 +13,7 @@
 
 import { StateCreator } from 'zustand';
 import { PanelGroupItemId } from '@perses-dev/core';
-import { insertPanelInLayout, UnpositionedPanelGroupItemLayout } from '../../utils/panelUtils';
+import { insertPanelInLayout, randomUUID, UnpositionedPanelGroupItemLayout } from '../../utils/panelUtils';
 import { generateId, Middleware } from './common';
 import { PanelGroupSlice } from './panel-group-slice';
 import { PanelSlice } from './panel-slice';
@@ -69,7 +69,7 @@ export function createDuplicatePanelSlice(): StateCreator<
           throw new Error(`Cannot find layout for Panel with key '${panelKey}'`);
         }
 
-        const dupePanelKey = crypto.randomUUID().replaceAll('-', '');
+        const dupePanelKey = randomUUID().replaceAll('-', '');
 
         state.panels[dupePanelKey] = panelToDupe;
 

--- a/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
+++ b/ui/dashboards/src/context/DashboardProvider/panel-editor-slice.ts
@@ -20,7 +20,7 @@ import {
   PanelGroupItemLayout,
 } from '@perses-dev/core';
 import { StateCreator } from 'zustand';
-import { getYForNewRow } from '../../utils';
+import { getYForNewRow, randomUUID } from '../../utils';
 import { generateId, Middleware, createPanelDefinition } from './common';
 import { PanelGroupSlice, addPanelGroup, createEmptyPanelGroup } from './panel-group-slice';
 import { PanelSlice } from './panel-slice';
@@ -186,7 +186,7 @@ export function createPanelEditorSlice(): StateCreator<
           panelDefinition: panelDefinition ?? get().initialValues?.panelDefinition ?? createPanelDefinition(),
         },
         applyChanges: (next) => {
-          const panelKey = crypto.randomUUID().replaceAll('-', '');
+          const panelKey = randomUUID().replaceAll('-', '');
           set((state) => {
             // Add a panel
             state.panels[panelKey] = next.panelDefinition;

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -54,6 +54,7 @@ function getPanelBounds({ x, y, w, h }: PanelGroupItemLayout): PanelGroupItemBou
   };
 }
 
+// LOGZ.IO CHANGE START:: Use crypto.randomUUID if available, otherwise use a fallback method.
 export const randomUUID = (): ReturnType<typeof crypto.randomUUID> => {
   return crypto?.randomUUID
     ? crypto.randomUUID()
@@ -63,6 +64,7 @@ export const randomUUID = (): ReturnType<typeof crypto.randomUUID> => {
         return v.toString(16);
       }) as ReturnType<typeof crypto.randomUUID>);
 };
+// LOGZ.IO CHANGE END:: Use crypto.randomUUID if available, otherwise use a fallback method.
 
 export type UnpositionedPanelGroupItemLayout = Omit<PanelGroupItemLayout, 'x' | 'y'>;
 

--- a/ui/dashboards/src/utils/panelUtils.ts
+++ b/ui/dashboards/src/utils/panelUtils.ts
@@ -54,6 +54,16 @@ function getPanelBounds({ x, y, w, h }: PanelGroupItemLayout): PanelGroupItemBou
   };
 }
 
+export const randomUUID = (): ReturnType<typeof crypto.randomUUID> => {
+  return crypto?.randomUUID
+    ? crypto.randomUUID()
+    : ('xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+        const r = (Math.random() * 16) | 0;
+        const v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      }) as ReturnType<typeof crypto.randomUUID>);
+};
+
 export type UnpositionedPanelGroupItemLayout = Omit<PanelGroupItemLayout, 'x' | 'y'>;
 
 /**


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

Fallback to randomUUID

# Description

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a `randomUUID` helper with fallback and replace direct `crypto.randomUUID` calls to generate panel keys when adding or duplicating panels.
> 
> - **Utils**:
>   - Add `randomUUID` helper in `ui/dashboards/src/utils/panelUtils.ts` with fallback when `crypto.randomUUID` is unavailable.
> - **DashboardProvider**:
>   - `duplicate-panel-slice.ts`: Use `randomUUID` to generate duplicated panel keys.
>   - `panel-editor-slice.ts`: Use `randomUUID` to generate new panel keys when adding panels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1349d02f1b62b0bb52789b957221761ccb1a52ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->