### PR TITLE
APPZ-994 Update column model to include accessorFn

### DIFF
--- a/ui/components/src/Table/model/table-model.ts
+++ b/ui/components/src/Table/model/table-model.ts
@@ -13,7 +13,6 @@
 
 import { Theme } from '@mui/material';
 import {
-  AccessorKeyColumnDef,
   CellContext,
   ColumnDef,
   CoreOptions,
@@ -21,6 +20,8 @@ import {
   RowData,
   RowSelectionState,
   SortingState,
+  ColumnDefBase,
+  AccessorFn,
 } from '@tanstack/react-table';
 import { CSSProperties } from 'react';
 
@@ -292,12 +293,27 @@ export interface TableColumnConfig<TableData>
   // https://github.com/TanStack/table/issues/4241
   // TODO: revisit issue thread and see if there are any workarounds we can
   // use.
+  // LOGZ.IO CHANGE START:: group by array field [APPZ-994]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extends Pick<AccessorKeyColumnDef<TableData, any>, 'accessorKey' | 'cell' | 'sortingFn'> {
+  extends Pick<ColumnDefBase<TableData, any>, 'cell' | 'sortingFn'> {
   /**
    * Text to display in the header for the column.
    */
   header: string;
+
+  /**
+   * Key to access the data for this column. Used when the column accesses a property directly.
+   * Cannot be used together with accessorFn.
+   */
+  accessorKey?: (string & {}) | keyof TableData;
+
+  /**
+   * Function to access the data for this column. Used when custom logic is needed to retrieve the value.
+   * Cannot be used together with accessorKey.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  accessorFn?: AccessorFn<TableData, any>;
+  // LOGZ.IO CHANGE END:: group by array field [APPZ-994]
 
   /**
    * Alignment of the content in the cell.


### PR DESCRIPTION
This pull request updates the `TableColumnConfig` interface in the table model to improve flexibility and compatibility with the latest TanStack Table library. The main change is replacing the use of `AccessorKeyColumnDef` with `ColumnDefBase`, and splitting the accessor logic into two distinct properties: `accessorKey` and `accessorFn`. This refactor enables support for more advanced use cases, such as grouping by array fields, and aligns with ongoing improvements in the table library.

**Table model improvements:**

* Refactored `TableColumnConfig` to extend `ColumnDefBase` instead of `AccessorKeyColumnDef`, removing the dependency on `accessorKey` in the base type. [[1]](diffhunk://#diff-067c2a0666c4823437047aa7d89aaf7a32b8f23d9ff6aa6c71ba34fe0ada5863L16-R24) [[2]](diffhunk://#diff-067c2a0666c4823437047aa7d89aaf7a32b8f23d9ff6aa6c71ba34fe0ada5863R296-R317)
* Introduced separate `accessorKey` and `accessorFn` properties to allow either direct property access or custom accessor logic, but not both at the same time. This enables more flexible column definitions and supports advanced grouping scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `accessorFn` (alongside `accessorKey`) and refactors `TableColumnConfig` to extend `ColumnDefBase` for more flexible column access.
> 
> - **Table model** (`ui/components/src/Table/model/table-model.ts`):
>   - Refactor `TableColumnConfig` to extend `ColumnDefBase` (from `AccessorKeyColumnDef`).
>   - Add optional `accessorKey` and `accessorFn` (mutually exclusive) for column value access.
>   - Update imports to include `ColumnDefBase` and `AccessorFn`; remove `AccessorKeyColumnDef`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6498e2108de1c447b17aa988f6ed110afe92d406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->