### PR TITLE
APPZ-1277 Change query names to A, B, etc

### DIFF
--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
@@ -23,6 +23,12 @@ import { InfoTooltip } from '@perses-dev/components';
 import { QueryData } from '../../runtime';
 import { PluginEditor, PluginEditorProps, PluginEditorRef } from '../PluginEditor';
 
+// LOGZ.IO CHANGE:: START [APPZ-1277]
+export const numberToUppercaseLetter = (number: number): string => {
+  return number < 0 || number > 25 ? `${number}` : String.fromCharCode(number + 65);
+};
+// LOGZ.IO CHANGE:: END
+
 /**
  * Properties for {@link QueryEditorContainer}
  */
@@ -78,7 +84,7 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
               {isCollapsed ? <ChevronRight /> : <ChevronDown />}
             </IconButton>
             <Typography variant="overline" component="h4">
-              Query #{index + 1}
+              {numberToUppercaseLetter(index) /* LOGZ.IO CHANGE:: [APPZ-1277] */}
             </Typography>
           </Stack>
           <Stack direction="row" alignItems="center">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces numeric query headers with uppercase letter labels (A–Z) via a new helper.
> 
> - **UI**:
>   - **Query label**: In `QueryEditorContainer.tsx`, replace `"Query #n"` with `numberToUppercaseLetter(index)` to show uppercase letters (A–Z) for query headers.
>   - **Utility**: Add `numberToUppercaseLetter(number)` to convert indices to letters; falls back to the number string for out-of-range values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb0aa69b1105f342829a977cdf65d90e685b7efc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->