### PR TITLE
Adjustable input width

### DIFF
--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -37,6 +37,20 @@ type VariableProps = {
   name: VariableName;
   source?: string;
 };
+//LOGZ.IO CHANGE START:: Variable input width calculation [APPZ-1764]
+const measurementCanvas = document.createElement('canvas');
+const measurementContext = measurementCanvas.getContext('2d');
+
+function getTextWidth(text: string, font: string): number {
+  if (!measurementContext) {
+    return text.length * 8;
+  }
+
+  measurementContext.font = font;
+  const metrics = measurementContext.measureText(text);
+  return Math.ceil(metrics.width);
+}
+//LOGZ.IO CHANGE END:: Variable input width calculation [APPZ-1764]
 
 function variableOptionToVariableValue(options: VariableOption | VariableOption[] | null): VariableValue {
   if (options === null) {
@@ -186,19 +200,25 @@ const StyledPopper = (props: PopperProps): ReactElement => (
   <Popper {...props} sx={{ minWidth: 'fit-content' }} placement="bottom-start" />
 );
 
-const LETTER_HSIZE = 8; // approximation
-const ARROW_OFFSET = 40; // right offset for list variables (= take into account the dropdown toggle size)
+//LOGZ.IO CHANGE START:: Variable input width calculation [APPZ-1764]
+const VARIABLE_INPUT_FONT = '400 14px Roboto, sans-serif';
+
+const ARROW_DROPDOWN_WIDTH = 40;
+const PADDING_BUFFER = 20;
 const getWidthPx = (inputValue: string, kind: 'list' | 'text'): number => {
-  const width = (inputValue.length + 1) * LETTER_HSIZE + (kind === 'list' ? ARROW_OFFSET : 0);
-  if (width < MIN_VARIABLE_WIDTH) {
+  const textWidth = getTextWidth(inputValue, VARIABLE_INPUT_FONT);
+
+  const totalWidth = textWidth + (kind === 'list' ? ARROW_DROPDOWN_WIDTH : 0) + PADDING_BUFFER;
+
+  if (totalWidth < MIN_VARIABLE_WIDTH) {
     return MIN_VARIABLE_WIDTH;
-  } else if (width > MAX_VARIABLE_WIDTH) {
+  } else if (totalWidth > MAX_VARIABLE_WIDTH) {
     return MAX_VARIABLE_WIDTH;
   } else {
-    return width;
+    return totalWidth;
   }
 };
-
+//LOGZ.IO CHANGE END:: Variable input width calculation [APPZ-1764]
 function ListVariable({ name, source }: VariableProps): ReactElement {
   const ctx = useVariableDefinitionAndState(name, source);
   const definition = ctx.definition as ListVariableDefinition;
@@ -315,7 +335,8 @@ function ListVariable({ name, source }: VariableProps): ReactElement {
           const { key, ...optionProps } = props;
           return (
             <li key={key} {...optionProps} style={{ padding: 0 }}>
-              <Checkbox style={{ marginRight: 8 }} checked={selected} />
+              {/* LOGZ.IO CHANGE:: Variable input width calculation [APPZ-1764] */}
+              <Checkbox checked={selected} />
               {option.label}
             </li>
           );

--- a/ui/dashboards/src/components/Variables/Variable.tsx
+++ b/ui/dashboards/src/components/Variables/Variable.tsx
@@ -37,17 +37,33 @@ type VariableProps = {
   name: VariableName;
   source?: string;
 };
+
 //LOGZ.IO CHANGE START:: Variable input width calculation [APPZ-1764]
-const measurementCanvas = document.createElement('canvas');
-const measurementContext = measurementCanvas.getContext('2d');
+let measurementCanvas: HTMLCanvasElement | null = null;
+let measurementContext: CanvasRenderingContext2D | null = null;
+
+function getMeasurementContext(): CanvasRenderingContext2D | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  if (!measurementCanvas) {
+    measurementCanvas = document.createElement('canvas');
+    measurementContext = measurementCanvas.getContext('2d');
+  }
+
+  return measurementContext;
+}
 
 function getTextWidth(text: string, font: string): number {
-  if (!measurementContext) {
+  const context = getMeasurementContext();
+
+  if (!context) {
     return text.length * 8;
   }
 
-  measurementContext.font = font;
-  const metrics = measurementContext.measureText(text);
+  context.font = font;
+  const metrics = context.measureText(text);
   return Math.ceil(metrics.width);
 }
 //LOGZ.IO CHANGE END:: Variable input width calculation [APPZ-1764]


### PR DESCRIPTION
This pull request improves the way input widths are calculated for variable inputs in the dashboard UI, replacing a rough character-based approximation with a more accurate measurement using the browser's canvas API. This ensures that variable input fields are sized more precisely to fit their contents, enhancing usability and appearance.

**Improvements to variable input width calculation:**

* Added a utility using a hidden canvas to measure the actual pixel width of input text, replacing the previous fixed-per-character approximation (`getTextWidth` function and related constants in `Variable.tsx`).
* Updated the `getWidthPx` function to use the new text measurement logic, and adjusted how dropdown arrow and padding are factored into the total width calculation for variable inputs.

## Before

<img width="619" height="159" alt="image" src="https://github.com/user-attachments/assets/9c2772c9-5997-4a50-9d70-b1b6eb278480" />

## After

<img width="641" height="147" alt="image" src="https://github.com/user-attachments/assets/f3c18f73-c793-43f0-a91d-ec88c0ee0301" />

**UI adjustment:**

* Removed the right margin from the `Checkbox` component in the list variable dropdown for a cleaner look.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches variable input sizing to canvas-measured text width and applies it to text/single-select inputs, plus a small checkbox spacing tweak.
> 
> - **UI (Variables)**:
>   - **Accurate width sizing**: Introduces canvas-based text measurement with `getMeasurementContext`/`getTextWidth` and updates `getWidthPx` to compute widths using `VARIABLE_INPUT_FONT`, `ARROW_DROPDOWN_WIDTH`, and `PADDING_BUFFER`, clamped to `MIN_VARIABLE_WIDTH`/`MAX_VARIABLE_WIDTH`.
>   - **Application**:
>     - Applies dynamic width to `TextVariable` and single-select `ListVariable` inputs; updates width on input change.
>   - **Minor UI tweak**: Removes extra spacing from list option `Checkbox` in `renderOption`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 994989da70b61f61127012a677a97bba447bf2d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->