### PR TITLE
Sticky toolbar

### DIFF
--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -72,7 +72,7 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps): Reac
             display="flex"
             flexWrap={!isSticky && isBiggerThanMd ? 'wrap' : 'nowrap'}
             maxWidth={isSticky || !isBiggerThanMd ? '100vw' : '100%'}
-            pt={1}
+            pt="6px"
             pl={isSticky ? 1 : 0}
             mt={isSticky && isBiggerThanMd ? 0.5 : 0}
             ml={isSticky && isBiggerThanMd ? 0.5 : 0}

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -110,10 +110,12 @@ export const DashboardToolbar = (props: DashboardToolbarProps): ReactElement => 
             display: 'flex',
             width: '100%',
             alignItems: 'start',
-            padding: (theme) => theme.spacing(1, 2, 0, 2),
+            padding: (theme) => theme.spacing(1, 2, 1, 2),
             flexDirection: isBiggerThanMd ? 'row' : 'column',
             flexWrap: 'nowrap',
             gap: 1,
+            borderBottom: '1px solid',
+            borderColor: (theme) => theme.palette.divider,
           }}
         >
           <Box width="100%">
@@ -127,7 +129,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps): ReactElement => 
             </ErrorBoundary>
           </Box>
           <Stack direction="row" ml="auto" flexWrap="wrap" justifyContent="end">
-            <Stack direction="row" spacing={1} mt={1} ml={1}>
+            <Stack direction="row" spacing={1} my={0.5} ml={1}>
               <TimeRangeControls />
               <DownloadButton />
               <EditJsonButton isReadonly={!isEditMode} />

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -122,10 +122,9 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
     <Box
       sx={{
         flexGrow: 1,
-        overflowX: 'hidden',
-        overflowY: 'auto',
         display: 'flex',
         flexDirection: 'column',
+        height: '100%',
       }}
     >
       <DashboardToolbar
@@ -140,7 +139,15 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
         onCancelButtonClick={onCancelButtonClick}
         dashboardControlsComponent={dashboardControlsComponent}
       />
-      <Box sx={{ paddingTop: 2, paddingX: 2, height: '100%' }}>
+      <Box
+        sx={{
+          flexGrow: 1,
+          overflowX: 'hidden',
+          overflowY: 'auto',
+          paddingTop: 1,
+          paddingX: 2,
+        }}
+      >
         <ErrorBoundary FallbackComponent={ErrorAlert}>
           <Dashboard
             emptyDashboardProps={{


### PR DESCRIPTION
![PinnedToolBar](https://github.com/user-attachments/assets/c3b5a83f-5554-4331-b13e-1b19cc2d047a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines dashboard toolbar/sticky toolbar spacing, adds a bottom divider, and moves scrolling into the content area with full-height layout.
> 
> - **UI layout tweaks**
>   - `DashboardApp.tsx`: Make root container fill height and shift scrolling to inner content (`flexGrow`, `height: '100%'`, move `overflowX/Y`), with reduced padding top.
>   - `DashboardToolbar.tsx`: Adjust toolbar padding and spacing (`padding` to include bottom, `my` on controls), and add a bottom divider (`borderBottom` with theme `divider`).
>   - `DashboardStickyToolbar.tsx`: Fine-tune variable row spacing (`pt="6px"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 963a7bbe053cb51910221f154822686fb493ac9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->