### PR TITLE
APPZ-955 Math queries support

### DIFF
--- a/ui/core/src/model/definitions.ts
+++ b/ui/core/src/model/definitions.ts
@@ -17,6 +17,7 @@
 export interface Definition<Spec> {
   kind: string;
   spec: Spec;
+  hidden?: boolean; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 
 /**

--- a/ui/core/src/model/query.ts
+++ b/ui/core/src/model/query.ts
@@ -19,6 +19,12 @@ import { LogData } from './log-data';
 
 interface QuerySpec<PluginSpec> {
   plugin: Definition<PluginSpec>;
+  /**
+   * When true, the query result is hidden from chart visualization but still executes.
+   * Hidden queries can still be referenced by other queries (e.g., Math expressions).
+   * Defaults to false (visible).
+   */
+  hidden?: boolean; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 /**
  * A generic query definition interface that can be extended to support more than just TimeSeriesQuery

--- a/ui/core/src/schema/panel.ts
+++ b/ui/core/src/schema/panel.ts
@@ -24,6 +24,7 @@ export const querySpecSchema: z.ZodSchema<QueryDefinition> = z.object({
   kind: z.string().min(1),
   spec: z.object({
     plugin: pluginSchema,
+    hidden: z.boolean().optional(), // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
   }),
 });
 

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -90,6 +90,7 @@ export function GridItemContent(props: GridItemContentProps): ReactElement {
         return {
           kind: query.spec.plugin.kind,
           spec: query.spec.plugin.spec,
+          hidden: query.spec.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
         };
       }),
     [queries]

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -35,9 +35,11 @@ export function PanelContent(props: PanelContentProps): ReactElement {
   // Render the panel if any query has data, or the panel doesn't have a query attached (for example MarkdownPanel).
   // Loading indicator or errors of other queries are shown in the panel header.
   const queryResultsWithData = useMemo(
-    () => queryResults.flatMap((q) => (q.data ? [{ data: q.data, definition: q.definition }] : [])),
+    () => queryResults.flatMap((q) => (q.data && !q.definition?.spec?.hidden ? [{ data: q.data, definition: q.definition }] : [])),
     [queryResults]
   );
+
+  const areAllQueriesHidden = useMemo(() => queryResults.every((q) => q.definition?.spec?.hidden ?? false), [queryResults]);
 
   // Show fullsize skeleton if the panel plugin is loading.
   if (isPanelLoading) {
@@ -51,7 +53,7 @@ export function PanelContent(props: PanelContentProps): ReactElement {
     );
   }
 
-  if (queryResultsWithData.length > 0 || queryResults.length === 0) {
+  if (queryResultsWithData.length > 0 || queryResults.length === 0 || areAllQueriesHidden) {
     return (
       <PanelPluginLoader
         kind={panelPluginKind}

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -35,11 +35,17 @@ export function PanelContent(props: PanelContentProps): ReactElement {
   // Render the panel if any query has data, or the panel doesn't have a query attached (for example MarkdownPanel).
   // Loading indicator or errors of other queries are shown in the panel header.
   const queryResultsWithData = useMemo(
-    () => queryResults.flatMap((q) => (q.data && !q.definition?.spec?.hidden ? [{ data: q.data, definition: q.definition }] : [])),
+    () =>
+      queryResults.flatMap((q) =>
+        q.data && !q.definition?.spec?.hidden ? [{ data: q.data, definition: q.definition }] : []
+      ),
     [queryResults]
   );
 
-  const areAllQueriesHidden = useMemo(() => queryResults.every((q) => q.definition?.spec?.hidden ?? false), [queryResults]);
+  const areAllQueriesHidden = useMemo(
+    () => queryResults.every((q) => q.definition?.spec?.hidden ?? false),
+    [queryResults]
+  );
 
   // Show fullsize skeleton if the panel plugin is loading.
   if (isPanelLoading) {

--- a/ui/dashboards/src/components/PanelDrawer/PanelQueriesSharedControls.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelQueriesSharedControls.tsx
@@ -54,6 +54,7 @@ export function PanelQueriesSharedControls({
       return {
         kind: query.spec.plugin.kind,
         spec: query.spec.plugin.spec,
+        hidden: query.spec.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
       };
     }) ?? [];
 

--- a/ui/dashboards/src/components/QueryViewerDialog/QueryViewerDialog.tsx
+++ b/ui/dashboards/src/components/QueryViewerDialog/QueryViewerDialog.tsx
@@ -33,6 +33,7 @@ export function QueryViewerDialog({ open, queryDefinitions, onClose }: QueryView
         queryItems.push(
           <React.Fragment key={`query-${index}`}>
             <PluginSpecEditor
+              index={index}
               value={query.spec.plugin.spec}
               pluginSelection={{ kind: query.spec.plugin.kind, type: query.kind }}
               onChange={(): void => {}}

--- a/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
@@ -126,21 +126,21 @@ export const MultiQueryEditor = forwardRef<PluginEditorRef, MultiQueryEditorProp
     });
   };
 
-
   // LOGZ.IO CHANGE START:: APPZ-955-math-on-queries-formulas
-  const handleVisibilityToggle = useCallback((index: number, isHidden: boolean) => {
-    onChange(
-      produce(queries, (draft) => {
-        const entry = draft?.[index];
-        if (entry) {
-          entry.spec.hidden = !isHidden;
-        }
-      })
-    );
-  }, [onChange, queries]);
+  const handleVisibilityToggle = useCallback(
+    (index: number, isHidden: boolean) => {
+      onChange(
+        produce(queries, (draft) => {
+          const entry = draft?.[index];
+          if (entry) {
+            entry.spec.hidden = !isHidden;
+          }
+        })
+      );
+    },
+    [onChange, queries]
+  );
   // LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas
-
-
 
   const handleQueryCollapseExpand = (index: number): void => {
     setQueriesCollapsed((queriesCollapsed) => {

--- a/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { forwardRef, ReactElement, useState } from 'react';
+import { forwardRef, ReactElement, useCallback, useState } from 'react';
 import { produce } from 'immer';
 import { Button, Stack } from '@mui/material';
 import AddIcon from 'mdi-material-ui/Plus';
@@ -126,6 +126,22 @@ export const MultiQueryEditor = forwardRef<PluginEditorRef, MultiQueryEditorProp
     });
   };
 
+
+  // LOGZ.IO CHANGE START:: APPZ-955-math-on-queries-formulas
+  const handleVisibilityToggle = useCallback((index: number, isHidden: boolean) => {
+    onChange(
+      produce(queries, (draft) => {
+        const entry = draft?.[index];
+        if (entry) {
+          entry.spec.hidden = !isHidden;
+        }
+      })
+    );
+  }, [onChange, queries]);
+  // LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas
+
+
+
   const handleQueryCollapseExpand = (index: number): void => {
     setQueriesCollapsed((queriesCollapsed) => {
       queriesCollapsed[index] = !queriesCollapsed[index];
@@ -153,8 +169,10 @@ export const MultiQueryEditor = forwardRef<PluginEditorRef, MultiQueryEditorProp
             queryResult={queryResults?.[i]}
             filteredQueryPlugins={filteredQueryPlugins}
             isCollapsed={!!queriesCollapsed[i]}
+            isHidden={query.spec.hidden ?? false}
             onChange={handleQueryChange}
             onDelete={queries.length > 1 ? handleQueryDelete : undefined}
+            onVisibilityToggle={handleVisibilityToggle}
             onCollapseExpand={handleQueryCollapseExpand}
           />
         ))}

--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.test.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.test.tsx
@@ -59,8 +59,7 @@ describe('QueryEditorContainer', () => {
   };
 
   Object.keys(renderingProps).forEach((key) => {
-    // LOGZ.IO CHANGE:: We removed the run query button and rely on blur event to run the query.
-    it(`should render ${key} without run query button`, () => {
+    test(`should render ${key} with run query button`, () => {
       renderWithContext(
         <QueryEditorContainer
           queryTypes={renderingProps[key]?.queryTypes as QueryPluginType[]}
@@ -72,8 +71,8 @@ describe('QueryEditorContainer', () => {
           onCollapseExpand={jest.fn()}
         />
       );
-      const runQuerybutton = screen.queryByTestId('run_query_button');
-      expect(runQuerybutton).not.toBeInTheDocument();
+      const runQueryButton = screen.queryByTestId('run_query_button');
+      expect(runQueryButton).toBeInTheDocument();
     });
   });
 });

--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
@@ -13,11 +13,13 @@
 
 import { produce } from 'immer';
 import { QueryDefinition, QueryPluginType } from '@perses-dev/core';
-import { Stack, IconButton, Typography, BoxProps, Box, CircularProgress } from '@mui/material';
+import { Stack, IconButton, Typography, BoxProps, Box, CircularProgress, Tooltip } from '@mui/material';
 import DeleteIcon from 'mdi-material-ui/DeleteOutline';
 import ChevronDown from 'mdi-material-ui/ChevronDown';
 import ChevronRight from 'mdi-material-ui/ChevronRight';
-import { forwardRef, ReactElement } from 'react';
+import EyeIcon from 'mdi-material-ui/Eye';
+import EyeOffIcon from 'mdi-material-ui/EyeOff';
+import { forwardRef, ReactElement, useCallback } from 'react';
 import AlertIcon from 'mdi-material-ui/Alert';
 import { InfoTooltip } from '@perses-dev/components';
 import { QueryData } from '../../runtime';
@@ -36,6 +38,8 @@ interface QueryEditorContainerProps {
   onCollapseExpand: (index: number) => void;
   isCollapsed?: boolean;
   onDelete?: (index: number) => void;
+  isHidden?: boolean;
+  onVisibilityToggle?: (index: number, isHidden: boolean) => void;
 }
 
 /**
@@ -45,9 +49,11 @@ interface QueryEditorContainerProps {
  * @param index the index of the query in the list
  * @param query the query definition
  * @param isCollapsed whether the query editor is collapsed or not
+ * @param isHidden whether the query is hidden or not
  * @param onDelete callback when the query is deleted
  * @param onChange callback when the query is changed
  * @param onCollapseExpand callback when the query is collapsed or expanded
+ * @param onVisibilityToggle callback when the query is hidden or shown
  * @constructor
  */
 
@@ -60,9 +66,11 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
       queryResult,
       filteredQueryPlugins,
       isCollapsed,
+      isHidden = false,
       onDelete,
       onChange,
       onCollapseExpand,
+      onVisibilityToggle,
     } = props;
     return (
       <Stack key={index} spacing={1}>
@@ -73,13 +81,16 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
           borderBottom={1}
           borderColor={(theme) => theme.palette.divider}
         >
-          <Stack direction="row">
+          <Stack direction="row" >
             <IconButton size="small" onClick={() => onCollapseExpand(index)}>
               {isCollapsed ? <ChevronRight /> : <ChevronDown />}
             </IconButton>
-            <Typography variant="overline" component="h4">
-              Query #{index + 1}
-            </Typography>
+            <Stack gap={0.5} direction={'row'} alignItems={'center'}>
+              <Typography variant="overline" component="h4">
+                Query #{index + 1}
+              </Typography>
+              {query.spec.hidden && <Typography variant='caption' color='secondary' component={'span'} fontStyle={'italic'}>Disabled</Typography>}
+            </Stack>
           </Stack>
           <Stack direction="row" alignItems="center">
             {queryResult?.isFetching && <CircularProgress aria-label="loading" size="1.125rem" />}
@@ -115,6 +126,20 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
                 </Stack>
               </InfoTooltip>
             )}
+            {/* LOGZ.IO CHANGE START:: APPZ-955-math-on-queries-formulas */}
+            {onVisibilityToggle && (
+              <Tooltip title={isHidden ? 'Show in chart' : 'Hide from chart'}>
+                <IconButton
+                  aria-label={isHidden ? 'show query in chart' : 'hide query from chart'}
+                  size="small"
+                  onClick={() => onVisibilityToggle?.(index, isHidden)}
+                  sx={{ color: isHidden ? 'text.disabled' : 'text.secondary' }}
+                >
+                  {isHidden ? <EyeOffIcon /> : <EyeIcon />}
+                </IconButton>
+              </Tooltip>
+            )}
+            {/* LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas */}
             {onDelete && (
               <IconButton aria-label="delete query" size="small" onClick={() => onDelete && onDelete(index)}>
                 <DeleteIcon />
@@ -130,6 +155,7 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
             queryResult={queryResult}
             filteredQueryPlugins={filteredQueryPlugins}
             onChange={(next) => onChange(index, next)}
+            index={index} // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
           />
         )}
       </Stack>
@@ -148,6 +174,7 @@ interface QueryEditorProps extends Omit<BoxProps, OmittedMuiProps> {
   queryResult?: QueryData;
   filteredQueryPlugins?: string[];
   onChange: (next: QueryDefinition) => void;
+  index: number; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 
 /**
@@ -159,7 +186,7 @@ interface QueryEditorProps extends Omit<BoxProps, OmittedMuiProps> {
  */
 
 const QueryEditor = forwardRef<PluginEditorRef, QueryEditorProps>((props, ref): ReactElement => {
-  const { value, onChange, queryTypes, queryResult, filteredQueryPlugins, ...others } = props;
+  const { value, onChange, queryTypes, queryResult, filteredQueryPlugins, index, ...others } = props;
   const handlePluginChange: PluginEditorProps['onChange'] = (next) => {
     onChange(
       produce(value, (draft) => {
@@ -174,7 +201,7 @@ const QueryEditor = forwardRef<PluginEditorRef, QueryEditorProps>((props, ref): 
     <Box {...others}>
       <PluginEditor
         ref={ref}
-        withRunQueryButton={false}
+        withRunQueryButton
         pluginTypes={queryTypes}
         pluginKindLabel="Query Type"
         value={{
@@ -187,6 +214,7 @@ const QueryEditor = forwardRef<PluginEditorRef, QueryEditorProps>((props, ref): 
         filteredQueryPlugins={filteredQueryPlugins}
         onQueryRefresh={queryResult?.refetch}
         onChange={handlePluginChange}
+        index={index} // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
       />
     </Box>
   );

--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
@@ -19,7 +19,7 @@ import ChevronDown from 'mdi-material-ui/ChevronDown';
 import ChevronRight from 'mdi-material-ui/ChevronRight';
 import EyeIcon from 'mdi-material-ui/Eye';
 import EyeOffIcon from 'mdi-material-ui/EyeOff';
-import { forwardRef, ReactElement, useCallback } from 'react';
+import { forwardRef, ReactElement } from 'react';
 import AlertIcon from 'mdi-material-ui/Alert';
 import { InfoTooltip } from '@perses-dev/components';
 import { QueryData } from '../../runtime';
@@ -81,15 +81,19 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
           borderBottom={1}
           borderColor={(theme) => theme.palette.divider}
         >
-          <Stack direction="row" >
+          <Stack direction="row">
             <IconButton size="small" onClick={() => onCollapseExpand(index)}>
               {isCollapsed ? <ChevronRight /> : <ChevronDown />}
             </IconButton>
-            <Stack gap={0.5} direction={'row'} alignItems={'center'}>
+            <Stack gap={0.5} direction="row" alignItems="center">
               <Typography variant="overline" component="h4">
                 Query #{index + 1}
               </Typography>
-              {query.spec.hidden && <Typography variant='caption' color='secondary' component={'span'} fontStyle={'italic'}>Disabled</Typography>}
+              {query.spec.hidden && (
+                <Typography variant="caption" color="secondary" component="span" fontStyle="italic">
+                  Disabled
+                </Typography>
+              )}
             </Stack>
           </Stack>
           <Stack direction="row" alignItems="center">

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -13,12 +13,14 @@
 
 import { Box, Button } from '@mui/material';
 import Reload from 'mdi-material-ui/Reload';
+import Play from 'mdi-material-ui/Play';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { forwardRef, ReactElement, useCallback, useImperativeHandle, useMemo, useState } from 'react';
 import { UnknownSpec } from '@perses-dev/core';
 import { PluginKindSelect } from '../PluginKindSelect';
 import { PluginSpecEditor } from '../PluginSpecEditor';
 import { PluginEditorProps, PluginEditorRef, usePluginEditor } from './plugin-editor-api';
+import isEqual from 'lodash/isEqual';
 
 /**
  * A combination `PluginKindSelect` and `PluginSpecEditor` component. This is meant for editing the `plugin` property
@@ -39,6 +41,7 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
     isReadonly,
     onQueryRefresh,
     filteredQueryPlugins,
+    index, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
     ...others
   } = props;
   const { pendingSelection, isLoading, error, onSelectionChange, onSpecChange } = usePluginEditor(props);
@@ -52,6 +55,9 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
   const [watchedQuery, setWatchQuery] = useState<string>(value.spec['query'] as string);
   const [watchedOtherSpecs, setWatchOtherSpecs] = useState<UnknownSpec>(value.spec);
 
+  const isSynced = watchedQuery === value.spec['query'] && isEqual(watchedOtherSpecs, value.spec); // // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
+
+
   const runQueryHandler = useCallback((): void => {
     onSpecChange({ ...value.spec, ...watchedOtherSpecs, query: watchedQuery });
     onQueryRefresh?.();
@@ -60,14 +66,14 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
   const queryHandlerSettings = useMemo(() => {
     return withRunQueryButton
       ? {
-          runWithOnBlur: false,
-          watchQueryChanges: (query: string): void => {
-            setWatchQuery(query);
-          },
-          setWatchOtherSpecs: (otherSpecs: UnknownSpec): void => {
-            setWatchOtherSpecs(otherSpecs);
-          },
-        }
+        runWithOnBlur: false,
+        watchQueryChanges: (query: string): void => {
+          setWatchQuery(query);
+        },
+        setWatchOtherSpecs: (otherSpecs: UnknownSpec): void => {
+          setWatchOtherSpecs(otherSpecs);
+        },
+      }
       : undefined;
   }, [withRunQueryButton]);
 
@@ -101,8 +107,8 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
         />
 
         {withRunQueryButton && !isLoading && (
-          <Button data-testid="run_query_button" variant="contained" startIcon={<Reload />} onClick={runQueryHandler}>
-            Run Query
+          <Button data-testid="run_query_button" variant={isSynced ? "outlined" : "contained"} startIcon={isSynced ? <Reload /> : <Play />} onClick={runQueryHandler} >
+            {isSynced ? `Reload Query` : `Run Query`}
           </Button>
         )}
       </Box>
@@ -114,6 +120,7 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
           onChange={onSpecChange}
           isReadonly={isReadonly}
           queryHandlerSettings={queryHandlerSettings}
+          index={index} // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
         />
       </ErrorBoundary>
     </Box>

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -17,10 +17,10 @@ import Play from 'mdi-material-ui/Play';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
 import { forwardRef, ReactElement, useCallback, useImperativeHandle, useMemo, useState } from 'react';
 import { UnknownSpec } from '@perses-dev/core';
+import isEqual from 'lodash/isEqual';
 import { PluginKindSelect } from '../PluginKindSelect';
 import { PluginSpecEditor } from '../PluginSpecEditor';
 import { PluginEditorProps, PluginEditorRef, usePluginEditor } from './plugin-editor-api';
-import isEqual from 'lodash/isEqual';
 
 /**
  * A combination `PluginKindSelect` and `PluginSpecEditor` component. This is meant for editing the `plugin` property
@@ -57,7 +57,6 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
 
   const isSynced = watchedQuery === value.spec['query'] && isEqual(watchedOtherSpecs, value.spec); // // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 
-
   const runQueryHandler = useCallback((): void => {
     onSpecChange({ ...value.spec, ...watchedOtherSpecs, query: watchedQuery });
     onQueryRefresh?.();
@@ -66,14 +65,14 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
   const queryHandlerSettings = useMemo(() => {
     return withRunQueryButton
       ? {
-        runWithOnBlur: false,
-        watchQueryChanges: (query: string): void => {
-          setWatchQuery(query);
-        },
-        setWatchOtherSpecs: (otherSpecs: UnknownSpec): void => {
-          setWatchOtherSpecs(otherSpecs);
-        },
-      }
+          runWithOnBlur: false,
+          watchQueryChanges: (query: string): void => {
+            setWatchQuery(query);
+          },
+          setWatchOtherSpecs: (otherSpecs: UnknownSpec): void => {
+            setWatchOtherSpecs(otherSpecs);
+          },
+        }
       : undefined;
   }, [withRunQueryButton]);
 
@@ -107,7 +106,12 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
         />
 
         {withRunQueryButton && !isLoading && (
-          <Button data-testid="run_query_button" variant={isSynced ? "outlined" : "contained"} startIcon={isSynced ? <Reload /> : <Play />} onClick={runQueryHandler} >
+          <Button
+            data-testid="run_query_button"
+            variant={isSynced ? 'outlined' : 'contained'}
+            startIcon={isSynced ? <Reload /> : <Play />}
+            onClick={runQueryHandler}
+          >
             {isSynced ? `Reload Query` : `Run Query`}
           </Button>
         )}

--- a/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
+++ b/ui/plugin-system/src/components/PluginEditor/PluginEditor.tsx
@@ -15,7 +15,7 @@ import { Box, Button } from '@mui/material';
 import Reload from 'mdi-material-ui/Reload';
 import Play from 'mdi-material-ui/Play';
 import { ErrorAlert, ErrorBoundary } from '@perses-dev/components';
-import { forwardRef, ReactElement, useCallback, useImperativeHandle, useMemo, useState } from 'react';
+import { forwardRef, ReactElement, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import { UnknownSpec } from '@perses-dev/core';
 import isEqual from 'lodash/isEqual';
 import { PluginKindSelect } from '../PluginKindSelect';
@@ -52,8 +52,16 @@ export const PluginEditor = forwardRef<PluginEditorRef, PluginEditorProps>((prop
      Reason: Only Query string field is common between all of them. Other specs may be different
      Example: Legend, and MinSteps
     */
-  const [watchedQuery, setWatchQuery] = useState<string>(value.spec['query'] as string);
+  const [watchedQuery, setWatchQuery] = useState<string>(value.spec.query as string);
   const [watchedOtherSpecs, setWatchOtherSpecs] = useState<UnknownSpec>(value.spec);
+
+  useEffect(() => {
+    setWatchQuery(value.spec.query as string);
+  }, [value.spec.query]);
+
+  useEffect(() => {
+    setWatchOtherSpecs(value.spec);
+  }, [value.spec]);
 
   const isSynced = watchedQuery === value.spec['query'] && isEqual(watchedOtherSpecs, value.spec); // // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 

--- a/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
+++ b/ui/plugin-system/src/components/PluginEditor/plugin-editor-api.ts
@@ -44,6 +44,7 @@ export interface PluginEditorProps extends Omit<BoxProps, OmittedMuiProps> {
   filteredQueryPlugins?: string[];
   onChange: (next: PluginEditorValue) => void;
   onQueryRefresh?: () => void;
+  index?: number; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 
 export interface PluginEditorRef {

--- a/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
+++ b/ui/plugin-system/src/components/Variables/VariableEditorForm/VariableEditorForm.tsx
@@ -166,7 +166,7 @@ function ListVariableEditorForm({ action, control }: KindVariableEditorFormProps
               render={({ field }) => {
                 return (
                   <PluginEditor
-                    withRunQueryButton={false}
+                    withRunQueryButton
                     width="100%"
                     pluginTypes={['Variable']}
                     pluginKindLabel="Source"

--- a/ui/plugin-system/src/model/plugin-base.ts
+++ b/ui/plugin-system/src/model/plugin-base.ts
@@ -43,6 +43,7 @@ export interface OptionsEditorProps<Spec> {
     watchQueryChanges: (query: string) => void;
     setWatchOtherSpecs: (otherSpecs: UnknownSpec) => void;
   };
+  index?: number; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 
 /**

--- a/ui/plugin-system/src/model/time-series-queries.ts
+++ b/ui/plugin-system/src/model/time-series-queries.ts
@@ -19,11 +19,16 @@ import { Plugin } from './plugin-base';
 /**
  * An object containing all the dependencies of a TimeSeriesQuery.
  */
-type TimeSeriesQueryPluginDependencies = {
+export type TimeSeriesQueryPluginDependencies = {
   /**
    * Returns a list of variables name this time series query depends on.
    */
   variables?: string[];
+  /**
+   * Returns a list of query indices (0-based) this time series query depends on.
+   * Used by plugins that need to reference results from other queries.
+   */
+  queries?: number[]; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 };
 
 /**
@@ -46,6 +51,18 @@ export interface TimeSeriesQueryContext {
   timeRange: AbsoluteTimeRange;
   variableState: VariableStateMap;
   datasourceStore: DatasourceStore;
+  // LOGZ.IO CHANGE START:: APPZ-955-math-on-queries-formulas
+  /**
+   * Results from other queries that this query may depend on.
+   * Map key is the query index (0-based), value is the resolved time series data.
+   * Only populated for queries that declare dependencies via dependsOn.queries.
+   */
+  resolvedQueryResults?: Map<number, TimeSeriesData>;
+  /**
+   * The index of the current query in the query list (0-based).
+   */
+  queryIndex?: number;
+  // LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas
 }
 
 export type TimeSeriesDataQuery = Query<TimeSeriesData, unknown, TimeSeriesData, QueryKey>;

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -82,6 +82,7 @@ export function DataQueriesProvider(props: DataQueriesProviderProps): ReactEleme
           kind: type,
           spec: {
             plugin: definition,
+            hidden: definition.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
           },
         };
       }),

--- a/ui/plugin-system/src/runtime/time-series-queries-utils.test.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.test.ts
@@ -1,0 +1,151 @@
+// LOGZ.IO FILE:: APPZ-955-math-on-queries-formulas
+
+import { TimeSeriesData } from '@perses-dev/core';
+import {
+  areDependenciesResolved,
+  detectCircularDependency,
+  formatCyclePath,
+} from './time-series-queries-utils';
+
+describe('areDependenciesResolved', () => {
+  test('returns true when query has no dependencies', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, []);
+    const resolvedResults = new Map<number, TimeSeriesData>();
+
+    expect(areDependenciesResolved(0, dependencies, resolvedResults)).toBe(true);
+  });
+
+  test('returns true when self-dependency only', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [0]);
+    const resolvedResults = new Map<number, TimeSeriesData>();
+
+    expect(areDependenciesResolved(0, dependencies, resolvedResults)).toBe(true);
+  });
+
+  test('returns false when external dependency not resolved', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [1]);
+    dependencies.set(1, []);
+    const resolvedResults = new Map<number, TimeSeriesData>();
+
+    expect(areDependenciesResolved(0, dependencies, resolvedResults)).toBe(false);
+  });
+
+  test('returns true when all external dependencies resolved', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [1, 2]);
+    dependencies.set(1, []);
+    dependencies.set(2, []);
+    const resolvedResults = new Map<number, TimeSeriesData>();
+    resolvedResults.set(1, { series: [], metadata: {} });
+    resolvedResults.set(2, { series: [], metadata: {} });
+
+    expect(areDependenciesResolved(0, dependencies, resolvedResults)).toBe(true);
+  });
+});
+
+describe('detectCircularDependency', () => {
+  test('returns no cycle for query with no dependencies', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, []);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(false);
+    expect(result.cyclePath).toEqual([]);
+  });
+
+  test('returns no cycle for linear dependency chain', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [1]);
+    dependencies.set(1, [2]);
+    dependencies.set(2, []);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(false);
+  });
+
+  test('detects simple circular dependency between two queries', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [1]);
+    dependencies.set(1, [0]);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(true);
+    expect(result.cyclePath).toContain(0);
+    expect(result.cyclePath).toContain(1);
+  });
+
+  test('detects circular dependency in chain of three queries', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [1]);
+    dependencies.set(1, [2]);
+    dependencies.set(2, [0]);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(true);
+    expect(result.cyclePath.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('ignores self-dependencies when detecting cycles', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [0]);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(false);
+  });
+
+  test('detects cycle with self-dependency and external cycle', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [0, 1]);
+    dependencies.set(1, [0]);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(true);
+  });
+
+  test('handles complex dependency graph with multiple branches', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [1, 2]);
+    dependencies.set(1, [3]);
+    dependencies.set(2, [3]);
+    dependencies.set(3, []);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(false);
+  });
+
+  test('handles complex dependency graph with cycle in one branch', () => {
+    const dependencies = new Map<number, number[]>();
+    dependencies.set(0, [1, 2]);
+    dependencies.set(1, [3]);
+    dependencies.set(2, [3]);
+    dependencies.set(3, [1]);
+
+    const result = detectCircularDependency(0, dependencies);
+
+    expect(result.hasCycle).toBe(true);
+  });
+});
+
+describe('formatCyclePath', () => {
+  test('formats single query index', () => {
+    expect(formatCyclePath([0])).toBe('Query #1');
+  });
+
+  test('formats multiple query indices with arrow separator', () => {
+    expect(formatCyclePath([0, 1])).toBe('Query #1 -> Query #2');
+  });
+
+  test('formats cycle path with three queries', () => {
+    expect(formatCyclePath([0, 1, 2])).toBe('Query #1 -> Query #2 -> Query #3');
+  });
+});

--- a/ui/plugin-system/src/runtime/time-series-queries-utils.test.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.test.ts
@@ -1,11 +1,7 @@
 // LOGZ.IO FILE:: APPZ-955-math-on-queries-formulas
 
 import { TimeSeriesData } from '@perses-dev/core';
-import {
-  areDependenciesResolved,
-  detectCircularDependency,
-  formatCyclePath,
-} from './time-series-queries-utils';
+import { areDependenciesResolved, detectCircularDependency, formatCyclePath } from './time-series-queries-utils';
 
 describe('areDependenciesResolved', () => {
   test('returns true when query has no dependencies', () => {

--- a/ui/plugin-system/src/runtime/time-series-queries-utils.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.ts
@@ -91,6 +91,52 @@ export function areDependenciesResolved(
   return externalDeps.every((depIdx) => resolvedResults.has(depIdx));
 }
 
+interface CircularDependencyState {
+  visited: Set<number>;
+  recursionStack: Set<number>;
+}
+
+function detectCircularDependencyInternal(
+  currentQueryIndex: number,
+  dependencies: Map<number, number[]>,
+  state: CircularDependencyState
+): { hasCycle: boolean; cyclePath: number[] } {
+  state.visited.add(currentQueryIndex);
+  state.recursionStack.add(currentQueryIndex);
+
+  const deps = dependencies.get(currentQueryIndex) ?? [];
+  const externalDeps = deps.filter((depIdx) => depIdx !== currentQueryIndex);
+
+  for (const depIndex of externalDeps) {
+    if (!state.visited.has(depIndex)) {
+      const result = detectCircularDependencyInternal(depIndex, dependencies, state);
+      if (result.hasCycle) {
+        return { hasCycle: true, cyclePath: [currentQueryIndex, ...result.cyclePath] };
+      }
+    } else if (state.recursionStack.has(depIndex)) {
+      return { hasCycle: true, cyclePath: [currentQueryIndex, depIndex] };
+    }
+  }
+
+  state.recursionStack.delete(currentQueryIndex);
+  return { hasCycle: false, cyclePath: [] };
+}
+
+export function detectCircularDependency(
+  queryIndex: number,
+  dependencies: Map<number, number[]>
+): { hasCycle: boolean; cyclePath: number[] } {
+  const state: CircularDependencyState = {
+    visited: new Set(),
+    recursionStack: new Set(),
+  };
+  return detectCircularDependencyInternal(queryIndex, dependencies, state);
+}
+
+export function formatCyclePath(cyclePath: number[]): string {
+  return cyclePath.map((idx) => `Query #${idx + 1}`).join(' -> ');
+}
+
 export function buildResolvedResults(results: Array<UseQueryResult<TimeSeriesData>>): Map<number, TimeSeriesData> {
   const map = new Map<number, TimeSeriesData>();
   results.forEach((result, idx) => {
@@ -154,7 +200,11 @@ export function createQueryConfig({
 
   const deps = dependencies.get(queryIndex) ?? [];
   const hasDeps = deps.length > 0;
-  const depsResolved = areDependenciesResolved(queryIndex, dependencies, resolvedResults);
+
+  const circularCheck = hasDeps ? detectCircularDependency(queryIndex, dependencies) : { hasCycle: false, cyclePath: [] };
+  const hasCircularDependency = circularCheck.hasCycle;
+
+  const depsResolved = hasCircularDependency || areDependenciesResolved(queryIndex, dependencies, resolvedResults);
   const depsFingerprint = hasDeps ? getDependencyFingerprint(resolvedResults, dependencies, queryIndex) : '';
 
   const finalQueryKey = hasDeps ? [...queryKey, queryIndex, 'deps', depsFingerprint] : [...queryKey, queryIndex];
@@ -164,6 +214,11 @@ export function createQueryConfig({
     enabled: (queryOptions?.enabled ?? true) && queryEnabled && depsResolved,
     queryKey: finalQueryKey,
     queryFn: async ({ signal }: { signal: AbortSignal }): Promise<TimeSeriesData> => {
+      if (hasCircularDependency) {
+        const cyclePath = formatCyclePath(circularCheck.cyclePath);
+        throw new Error(`Circular dependency detected: ${cyclePath}. Queries cannot depend on each other in a cycle.`);
+      }
+
       const loadedPlugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
       const ctx: TimeSeriesQueryContext = {
         ...context,

--- a/ui/plugin-system/src/runtime/time-series-queries-utils.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.ts
@@ -15,11 +15,7 @@
 
 import { TimeSeriesData, TimeSeriesQueryDefinition } from '@perses-dev/core';
 import { QueryKey, QueryObserverOptions, UseQueryResult } from '@tanstack/react-query';
-import {
-  TimeSeriesQueryContext,
-  TimeSeriesQueryPlugin,
-  TimeSeriesQueryPluginDependencies,
-} from '../model';
+import { TimeSeriesQueryContext, TimeSeriesQueryPlugin, TimeSeriesQueryPluginDependencies } from '../model';
 import { usePluginRegistry } from './plugin-registry';
 import { filterVariableStateMap, getVariableValuesKey } from './utils';
 
@@ -95,9 +91,7 @@ export function areDependenciesResolved(
   return externalDeps.every((depIdx) => resolvedResults.has(depIdx));
 }
 
-export function buildResolvedResults(
-  results: Array<UseQueryResult<TimeSeriesData>>
-): Map<number, TimeSeriesData> {
+export function buildResolvedResults(results: Array<UseQueryResult<TimeSeriesData>>): Map<number, TimeSeriesData> {
   const map = new Map<number, TimeSeriesData>();
   results.forEach((result, idx) => {
     if (result?.data) {
@@ -121,16 +115,18 @@ export function getDependencyFingerprint(
   const deps = dependencies.get(queryIndex) ?? [];
   if (deps.length === 0) return '';
 
-  return deps.map((depIdx) => {
-    const data = resolvedResults.get(depIdx);
-    if (!data) return `${depIdx}:null`;
+  return deps
+    .map((depIdx) => {
+      const data = resolvedResults.get(depIdx);
+      if (!data) return `${depIdx}:null`;
 
-    const seriesCount = data.series?.length ?? 0;
-    const firstTs = data.series?.[0]?.values?.[0]?.[0] ?? 0;
-    const lastTs = data.series?.[0]?.values?.slice(-1)?.[0]?.[0] ?? 0;
+      const seriesCount = data.series?.length ?? 0;
+      const firstTs = data.series?.[0]?.values?.[0]?.[0] ?? 0;
+      const lastTs = data.series?.[0]?.values?.slice(-1)?.[0]?.[0] ?? 0;
 
-    return `${depIdx}:${seriesCount}:${firstTs}:${lastTs}`;
-  }).join('|');
+      return `${depIdx}:${seriesCount}:${firstTs}:${lastTs}`;
+    })
+    .join('|');
 }
 
 export interface CreateQueryConfigParams {
@@ -161,9 +157,7 @@ export function createQueryConfig({
   const depsResolved = areDependenciesResolved(queryIndex, dependencies, resolvedResults);
   const depsFingerprint = hasDeps ? getDependencyFingerprint(resolvedResults, dependencies, queryIndex) : '';
 
-  const finalQueryKey = hasDeps
-    ? [...queryKey, queryIndex, 'deps', depsFingerprint]
-    : [...queryKey, queryIndex];
+  const finalQueryKey = hasDeps ? [...queryKey, queryIndex, 'deps', depsFingerprint] : [...queryKey, queryIndex];
 
   return {
     ...queryOptions,

--- a/ui/plugin-system/src/runtime/time-series-queries-utils.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.ts
@@ -1,0 +1,182 @@
+// LOGZ.IO FILE:: APPZ-955-math-on-queries-formulas
+
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TimeSeriesData, TimeSeriesQueryDefinition } from '@perses-dev/core';
+import { QueryKey, QueryObserverOptions, UseQueryResult } from '@tanstack/react-query';
+import {
+  TimeSeriesQueryContext,
+  TimeSeriesQueryPlugin,
+  TimeSeriesQueryPluginDependencies,
+} from '../model';
+import { usePluginRegistry } from './plugin-registry';
+import { filterVariableStateMap, getVariableValuesKey } from './utils';
+
+export const TIME_SERIES_QUERY_KEY = 'TimeSeriesQuery';
+
+export interface QueryOptionsResult {
+  queryKey: QueryKey;
+  queryEnabled: boolean;
+  dependencies: TimeSeriesQueryPluginDependencies;
+}
+
+export function getQueryOptions(
+  plugin: TimeSeriesQueryPlugin | undefined,
+  definition: TimeSeriesQueryDefinition,
+  context: TimeSeriesQueryContext
+): QueryOptionsResult {
+  const { timeRange, suggestedStepMs, mode, variableState } = context;
+
+  const dependencies = plugin?.dependsOn ? plugin.dependsOn(definition.spec.plugin.spec, context) : {};
+  const variableDependencies = dependencies?.variables;
+
+  const filteredVariabledState = filterVariableStateMap(variableState, variableDependencies);
+  const variablesValueKey = getVariableValuesKey(filteredVariabledState);
+  const definitionQueryKey: TimeSeriesQueryDefinition = { ...definition, spec: { plugin: definition.spec.plugin } };
+
+  const queryKey = [
+    'query',
+    TIME_SERIES_QUERY_KEY,
+    definitionQueryKey,
+    timeRange,
+    variablesValueKey,
+    suggestedStepMs,
+    mode,
+  ] as const;
+
+  let waitToLoad = false;
+  if (variableDependencies) {
+    waitToLoad = variableDependencies.some((v) => variableState[v]?.loading);
+  }
+
+  const queryEnabled = plugin !== undefined && !waitToLoad;
+
+  return { queryKey, queryEnabled, dependencies };
+}
+
+export function extractQueryDependencies(
+  definitions: TimeSeriesQueryDefinition[],
+  plugins: Array<{ data?: TimeSeriesQueryPlugin }>,
+  context: TimeSeriesQueryContext
+): Map<number, number[]> {
+  const dependencies = new Map<number, number[]>();
+
+  definitions.forEach((definition, idx) => {
+    const plugin = plugins[idx]?.data;
+    const deps = plugin?.dependsOn ? plugin.dependsOn(definition.spec.plugin.spec, context) : {};
+    dependencies.set(idx, deps?.queries ?? []);
+  });
+
+  return dependencies;
+}
+
+export function areDependenciesResolved(
+  queryIndex: number,
+  dependencies: Map<number, number[]>,
+  resolvedResults: Map<number, TimeSeriesData>
+): boolean {
+  const deps = dependencies.get(queryIndex) ?? [];
+  if (deps.length === 0) return true;
+
+  const externalDeps = deps.filter((depIdx) => depIdx !== queryIndex);
+  if (externalDeps.length === 0) return true;
+
+  return externalDeps.every((depIdx) => resolvedResults.has(depIdx));
+}
+
+export function buildResolvedResults(
+  results: Array<UseQueryResult<TimeSeriesData>>
+): Map<number, TimeSeriesData> {
+  const map = new Map<number, TimeSeriesData>();
+  results.forEach((result, idx) => {
+    if (result?.data) {
+      map.set(idx, result.data);
+    }
+  });
+  return map;
+}
+
+export function getResultsFingerprint(map: Map<number, TimeSeriesData>): string {
+  return Array.from(map.entries())
+    .map(([idx, data]) => `${idx}:${data.series?.length ?? 0}`)
+    .join(',');
+}
+
+export function getDependencyFingerprint(
+  resolvedResults: Map<number, TimeSeriesData>,
+  dependencies: Map<number, number[]>,
+  queryIndex: number
+): string {
+  const deps = dependencies.get(queryIndex) ?? [];
+  if (deps.length === 0) return '';
+
+  return deps.map((depIdx) => {
+    const data = resolvedResults.get(depIdx);
+    if (!data) return `${depIdx}:null`;
+
+    const seriesCount = data.series?.length ?? 0;
+    const firstTs = data.series?.[0]?.values?.[0]?.[0] ?? 0;
+    const lastTs = data.series?.[0]?.values?.slice(-1)?.[0]?.[0] ?? 0;
+
+    return `${depIdx}:${seriesCount}:${firstTs}:${lastTs}`;
+  }).join('|');
+}
+
+export interface CreateQueryConfigParams {
+  definition: TimeSeriesQueryDefinition;
+  plugin: TimeSeriesQueryPlugin | undefined;
+  context: TimeSeriesQueryContext;
+  queryIndex: number;
+  getPlugin: ReturnType<typeof usePluginRegistry>['getPlugin'];
+  queryOptions?: Omit<QueryObserverOptions, 'queryKey'>;
+  resolvedResults: Map<number, TimeSeriesData>;
+  dependencies: Map<number, number[]>;
+}
+
+export function createQueryConfig({
+  definition,
+  plugin,
+  context,
+  queryIndex,
+  getPlugin,
+  queryOptions,
+  resolvedResults,
+  dependencies,
+}: CreateQueryConfigParams): QueryObserverOptions {
+  const { queryEnabled, queryKey } = getQueryOptions(plugin, definition, context);
+
+  const deps = dependencies.get(queryIndex) ?? [];
+  const hasDeps = deps.length > 0;
+  const depsResolved = areDependenciesResolved(queryIndex, dependencies, resolvedResults);
+  const depsFingerprint = hasDeps ? getDependencyFingerprint(resolvedResults, dependencies, queryIndex) : '';
+
+  const finalQueryKey = hasDeps
+    ? [...queryKey, queryIndex, 'deps', depsFingerprint]
+    : [...queryKey, queryIndex];
+
+  return {
+    ...queryOptions,
+    enabled: (queryOptions?.enabled ?? true) && queryEnabled && depsResolved,
+    queryKey: finalQueryKey,
+    queryFn: async ({ signal }: { signal: AbortSignal }): Promise<TimeSeriesData> => {
+      const loadedPlugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
+      const ctx: TimeSeriesQueryContext = {
+        ...context,
+        queryIndex,
+        resolvedQueryResults: resolvedResults,
+      };
+      return loadedPlugin.getTimeSeriesData(definition.spec.plugin.spec, ctx, signal);
+    },
+  };
+}

--- a/ui/plugin-system/src/runtime/time-series-queries-utils.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.ts
@@ -159,9 +159,11 @@ export function getDependencyFingerprint(
   queryIndex: number
 ): string {
   const deps = dependencies.get(queryIndex) ?? [];
-  if (deps.length === 0) return '';
+  const externalDeps = deps.filter((depIdx) => depIdx !== queryIndex);
 
-  return deps
+  if (externalDeps.length === 0) return '';
+
+  return externalDeps
     .map((depIdx) => {
       const data = resolvedResults.get(depIdx);
       if (!data) return `${depIdx}:null`;
@@ -201,7 +203,9 @@ export function createQueryConfig({
   const deps = dependencies.get(queryIndex) ?? [];
   const hasDeps = deps.length > 0;
 
-  const circularCheck = hasDeps ? detectCircularDependency(queryIndex, dependencies) : { hasCycle: false, cyclePath: [] };
+  const circularCheck = hasDeps
+    ? detectCircularDependency(queryIndex, dependencies)
+    : { hasCycle: false, cyclePath: [] };
   const hasCircularDependency = circularCheck.hasCycle;
 
   const depsResolved = hasCircularDependency || areDependenciesResolved(queryIndex, dependencies, resolvedResults);

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -59,7 +59,7 @@ export function useTimeSeriesQuery(
   const { queryEnabled, queryKey } = getQueryOptions(plugin, definition, context);
 
   return useQuery({
-    enabled: (queryOptions?.enabled ?? true) || queryEnabled,
+    enabled: (queryOptions?.enabled ?? true) && queryEnabled,
     queryKey: queryKey,
     queryFn: ({ signal }) => {
       if (plugin === undefined) {

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -12,138 +12,123 @@
 // limitations under the License.
 
 import { TimeSeriesData, TimeSeriesQueryDefinition, UnknownSpec } from '@perses-dev/core';
-import {
-  Query,
-  QueryCache,
-  QueryKey,
-  QueryObserverOptions,
-  useQuery,
-  useQueryClient,
-  UseQueryResult,
-} from '@tanstack/react-query';
-import { TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryMode, TimeSeriesQueryPlugin } from '../model';
+import { Query, QueryCache, QueryKey, QueryObserverOptions, useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { TimeSeriesDataQuery } from '../model';
+import { useMemo, useState, useEffect } from 'react';
+import { TimeSeriesQueryContext, TimeSeriesQueryMode } from '../model';
 import { useStableQueries } from '../hooks';
 import { useTimeRange } from './TimeRangeProvider';
 import { useDatasourceStore } from './datasources';
 import { usePlugin, usePluginRegistry, usePlugins } from './plugin-registry';
-import { filterVariableStateMap, getVariableValuesKey } from './utils';
 import { useAllVariableValues } from './variables';
+// LOGZ.IO CHANGE START:: APPZ-955-math-on-queries-formulas
+import {
+  TIME_SERIES_QUERY_KEY,
+  getQueryOptions,
+  extractQueryDependencies,
+  buildResolvedResults,
+  getResultsFingerprint,
+  createQueryConfig,
+} from './time-series-queries-utils';
+// LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas
+
+export { TIME_SERIES_QUERY_KEY } from './time-series-queries-utils';
 
 export interface UseTimeSeriesQueryOptions {
   suggestedStepMs?: number;
   mode?: TimeSeriesQueryMode;
 }
 
-export const TIME_SERIES_QUERY_KEY = 'TimeSeriesQuery';
-
-function getQueryOptions({
-  plugin,
-  definition,
-  context,
-}: {
-  plugin?: TimeSeriesQueryPlugin;
-  definition: TimeSeriesQueryDefinition;
-  context: TimeSeriesQueryContext;
-}): {
-  queryKey: QueryKey;
-  queryEnabled: boolean;
-} {
-  const { timeRange, suggestedStepMs, mode, variableState } = context;
-
-  const dependencies = plugin?.dependsOn ? plugin.dependsOn(definition.spec.plugin.spec, context) : {};
-  const variableDependencies = dependencies?.variables;
-
-  // Determine queryKey
-  const filteredVariabledState = filterVariableStateMap(variableState, variableDependencies);
-  const variablesValueKey = getVariableValuesKey(filteredVariabledState);
-
-  const queryKey = [
-    'query',
-    TIME_SERIES_QUERY_KEY,
-    definition,
-    timeRange,
-    variablesValueKey,
-    suggestedStepMs,
-    mode,
-  ] as const;
-
-  // Determine queryEnabled
-  let waitToLoad = false;
-  if (variableDependencies) {
-    waitToLoad = variableDependencies.some((v) => variableState[v]?.loading);
-  }
-
-  const queryEnabled = plugin !== undefined && !waitToLoad;
-
-  return {
-    queryKey,
-    queryEnabled,
-  };
-}
-
 /**
  * Runs a time series query using a plugin and returns the results.
  */
-export const useTimeSeriesQuery = (
+export function useTimeSeriesQuery(
   definition: TimeSeriesQueryDefinition,
   options?: UseTimeSeriesQueryOptions,
   queryOptions?: QueryObserverOptions<TimeSeriesData>
-): UseQueryResult<TimeSeriesData> => {
+): UseQueryResult<TimeSeriesData> {
   const { data: plugin } = usePlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
   const context = useTimeSeriesQueryContext();
-  const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
+  const { queryEnabled, queryKey } = getQueryOptions(plugin, definition, context);
+
   return useQuery({
     enabled: (queryOptions?.enabled ?? true) || queryEnabled,
     queryKey: queryKey,
     queryFn: ({ signal }) => {
-      // The 'enabled' option should prevent this from happening, but make TypeScript happy by checking
       if (plugin === undefined) {
         throw new Error('Expected plugin to be loaded');
       }
-      // Keep options out of query key so we don't re-run queries because suggested step changes
       const ctx: TimeSeriesQueryContext = { ...context, suggestedStepMs: options?.suggestedStepMs };
       return plugin.getTimeSeriesData(definition.spec.plugin.spec, ctx, signal);
     },
   });
-};
+}
 
 /**
  * Runs multiple time series queries using plugins and returns the results.
+ * Supports queries that depend on other query results via dependsOn.queries.
+ * Handles chained dependencies of any depth via dynamic dependency resolution.
  */
 export function useTimeSeriesQueries(
   definitions: TimeSeriesQueryDefinition[],
   options?: UseTimeSeriesQueryOptions,
   queryOptions?: Omit<QueryObserverOptions, 'queryKey'>
 ): Array<UseQueryResult<TimeSeriesData>> {
+  // Track resolved results in state to trigger re-renders for dependent queries
+  const [resolvedResults, setResolvedResults] = useState<Map<number, TimeSeriesData>>(new Map());
+
   const { getPlugin } = usePluginRegistry();
-  const context = {
-    ...useTimeSeriesQueryContext(),
-    mode: options?.mode,
-    suggestedStepMs: options?.suggestedStepMs,
-  };
+  const baseContext = useTimeSeriesQueryContext();
+
+  const context = useMemo(
+    () => ({
+      ...baseContext,
+      mode: options?.mode,
+      suggestedStepMs: options?.suggestedStepMs,
+    }),
+    [baseContext, options?.mode, options?.suggestedStepMs]
+  );
 
   const pluginLoaderResponse = usePlugins(
     TIME_SERIES_QUERY_KEY,
     definitions.map((d) => ({ kind: d.spec.plugin.kind }))
   );
 
+  // LOGZ.IO CHANGE START:: APPZ-955-math-on-queries-formulas
+  const dependencies = useMemo(
+    () => extractQueryDependencies(definitions, pluginLoaderResponse, context),
+    [definitions, pluginLoaderResponse, context]
+  );
+
+  const queries = useMemo(() => {
+    return definitions.map((definition, idx) => createQueryConfig({
+      definition,
+      plugin: pluginLoaderResponse[idx]?.data,
+      context,
+      queryIndex: idx,
+      getPlugin,
+      queryOptions,
+      resolvedResults,
+      dependencies,
+    }));
+  }, [definitions, pluginLoaderResponse, context, dependencies, getPlugin, queryOptions, resolvedResults]);
+
   // LOGZ.IO CHANGE:: Performance optimization [APPZ-359] useStableQueries()
-  return useStableQueries({
-    queries: definitions.map((definition, idx) => {
-      const plugin = pluginLoaderResponse[idx]?.data;
-      const { queryEnabled, queryKey } = getQueryOptions({ plugin, definition, context });
-      return {
-        ...queryOptions,
-        enabled: (queryOptions?.enabled ?? true) && queryEnabled,
-        queryKey: queryKey,
-        queryFn: async ({ signal }: { signal: AbortSignal }): Promise<TimeSeriesData> => {
-          const plugin = await getPlugin(TIME_SERIES_QUERY_KEY, definition.spec.plugin.kind);
-          const data = await plugin.getTimeSeriesData(definition.spec.plugin.spec, context, signal);
-          return data;
-        },
-      } as QueryObserverOptions;
-    }),
-  }) as Array<UseQueryResult<TimeSeriesData>>;
+  const results = useStableQueries({ queries }) as Array<UseQueryResult<TimeSeriesData>>;
+
+  // Sync resolved results when query data changes
+  useEffect(() => {
+    const newResolved = buildResolvedResults(results);
+    const newFingerprint = getResultsFingerprint(newResolved);
+    const currentFingerprint = getResultsFingerprint(resolvedResults);
+
+    if (newFingerprint !== currentFingerprint) {
+      setResolvedResults(newResolved);
+    }
+  }, [results, resolvedResults]);
+
+  return results;
+  // LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas
 }
 
 /**

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -12,10 +12,17 @@
 // limitations under the License.
 
 import { TimeSeriesData, TimeSeriesQueryDefinition, UnknownSpec } from '@perses-dev/core';
-import { Query, QueryCache, QueryKey, QueryObserverOptions, useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
-import { TimeSeriesDataQuery } from '../model';
+import {
+  Query,
+  QueryCache,
+  QueryKey,
+  QueryObserverOptions,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from '@tanstack/react-query';
 import { useMemo, useState, useEffect } from 'react';
-import { TimeSeriesQueryContext, TimeSeriesQueryMode } from '../model';
+import { TimeSeriesDataQuery, TimeSeriesQueryContext, TimeSeriesQueryMode } from '../model';
 import { useStableQueries } from '../hooks';
 import { useTimeRange } from './TimeRangeProvider';
 import { useDatasourceStore } from './datasources';
@@ -101,16 +108,18 @@ export function useTimeSeriesQueries(
   );
 
   const queries = useMemo(() => {
-    return definitions.map((definition, idx) => createQueryConfig({
-      definition,
-      plugin: pluginLoaderResponse[idx]?.data,
-      context,
-      queryIndex: idx,
-      getPlugin,
-      queryOptions,
-      resolvedResults,
-      dependencies,
-    }));
+    return definitions.map((definition, idx) =>
+      createQueryConfig({
+        definition,
+        plugin: pluginLoaderResponse[idx]?.data,
+        context,
+        queryIndex: idx,
+        getPlugin,
+        queryOptions,
+        resolvedResults,
+        dependencies,
+      })
+    );
   }, [definitions, pluginLoaderResponse, context, dependencies, getPlugin, queryOptions, resolvedResults]);
 
   // LOGZ.IO CHANGE:: Performance optimization [APPZ-359] useStableQueries()


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Connected to https://github.com/logzio/gaia-hermes-ws/pull/15953
- Extended TimeSeriesQueryPluginDependencies with queries?: number[] to declare dependencies on other queries
- Extended TimeSeriesQueryContext with resolvedQueryResults and queryIndex for plugins to access resolved data
- Added `hidden?: boolean` to QuerySpec to hide queries from chart visualization while still executing them
- Implemented dynamic dependency resolution in useTimeSeriesQueries supporting unlimited chaining depth
- Added fingerprinting for cache invalidation when dependency data changes
- Extracted query utilities to time-series-queries-utils.ts
- Added visibility toggle (eye icon) in QueryEditorContainer
- Updated PanelContent to filter hidden queries and show "no data" when all visible queries are hidden
- Added `Reload Query` and `Run Query` button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query execution and caching behavior (dependency gating, query keys, cycle detection), which can impact data loading and performance across dashboards despite being mostly additive and covered by new unit tests.
> 
> **Overview**
> Enables *math/derived queries* by letting TimeSeries query plugins declare inter-query dependencies (`dependsOn.queries`) and by passing `resolvedQueryResults` + `queryIndex` into `TimeSeriesQueryContext`; `useTimeSeriesQueries` now dynamically gates execution until dependencies are resolved, fingerprints dependency data into the React Query key, and detects/throws on circular dependencies (refactored into `time-series-queries-utils.ts` with tests).
> 
> Adds a `hidden` flag to `QuerySpec`/schema and threads it through `DataQueriesProvider`/dashboard panel wiring so queries can execute but be excluded from chart rendering; `PanelContent` filters hidden results and treats “all queries hidden” as a valid render state.
> 
> Updates the query editing UI to support this workflow: adds a per-query visibility toggle (eye icon), passes `index` through `PluginEditor`/`PluginSpecEditor`, and re-enables an explicit Run/Reload button with synced-state styling (also used in variable editor), with tests updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50bb43c721ab7f3c0688156ab25834f21b3dc641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->