### PR TITLE
APPZ-1234 Math query hot fix

### DIFF
--- a/ui/plugin-system/src/runtime/time-series-queries-utils.test.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.test.ts
@@ -1,7 +1,12 @@
 // LOGZ.IO FILE:: APPZ-955-math-on-queries-formulas
 
 import { TimeSeriesData } from '@perses-dev/core';
-import { areDependenciesResolved, detectCircularDependency, formatCyclePath } from './time-series-queries-utils';
+import {
+  areDependenciesResolved,
+  areMapsEqual,
+  detectCircularDependency,
+  formatCyclePath,
+} from './time-series-queries-utils';
 
 describe('areDependenciesResolved', () => {
   test('returns true when query has no dependencies', () => {
@@ -143,5 +148,56 @@ describe('formatCyclePath', () => {
 
   test('formats cycle path with three queries', () => {
     expect(formatCyclePath([0, 1, 2])).toBe('Query #1 -> Query #2 -> Query #3');
+  });
+});
+
+describe('areMapsEqual', () => {
+  const createMockData = (): TimeSeriesData => ({ series: [], metadata: {} });
+
+  test('returns true for two empty maps', () => {
+    const map1 = new Map<number, TimeSeriesData>();
+    const map2 = new Map<number, TimeSeriesData>();
+
+    expect(areMapsEqual(map1, map2)).toBe(true);
+  });
+
+  test('returns false when maps have different sizes', () => {
+    const map1 = new Map<number, TimeSeriesData>();
+    const map2 = new Map<number, TimeSeriesData>();
+    map1.set(0, createMockData());
+
+    expect(areMapsEqual(map1, map2)).toBe(false);
+  });
+
+  test('returns true when maps have same keys with same references', () => {
+    const data1 = createMockData();
+    const data2 = createMockData();
+    const map1 = new Map<number, TimeSeriesData>();
+    const map2 = new Map<number, TimeSeriesData>();
+    map1.set(0, data1);
+    map1.set(1, data2);
+    map2.set(0, data1);
+    map2.set(1, data2);
+
+    expect(areMapsEqual(map1, map2)).toBe(true);
+  });
+
+  test('returns false when maps have same keys but different references', () => {
+    const map1 = new Map<number, TimeSeriesData>();
+    const map2 = new Map<number, TimeSeriesData>();
+    map1.set(0, createMockData());
+    map2.set(0, createMockData());
+
+    expect(areMapsEqual(map1, map2)).toBe(false);
+  });
+
+  test('returns false when maps have different keys', () => {
+    const data = createMockData();
+    const map1 = new Map<number, TimeSeriesData>();
+    const map2 = new Map<number, TimeSeriesData>();
+    map1.set(0, data);
+    map2.set(1, data);
+
+    expect(areMapsEqual(map1, map2)).toBe(false);
   });
 });

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -127,6 +127,7 @@ export function useTimeSeriesQueries(
 
   // Memoize resolved results computation to avoid rebuilding in every effect run
   const newResolved = useMemo(() => buildResolvedResults(results), [results]);
+  const hasPendingDependentQueries = definitions.length !== resolvedResults.size;
 
   // Sync resolved results when data references change
   useEffect(() => {
@@ -135,7 +136,10 @@ export function useTimeSeriesQueries(
     }
   }, [newResolved, resolvedResults]);
 
-  return results;
+  return results.map((result) => ({
+    ...result,
+    isFetching: result.isFetching || hasPendingDependentQueries,
+  }));
   // LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas
 }
 

--- a/ui/plugin-system/src/runtime/time-series-queries.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries.ts
@@ -127,7 +127,6 @@ export function useTimeSeriesQueries(
 
   // Memoize resolved results computation to avoid rebuilding in every effect run
   const newResolved = useMemo(() => buildResolvedResults(results), [results]);
-  const hasPendingDependentQueries = definitions.length !== resolvedResults.size;
 
   // Sync resolved results when data references change
   useEffect(() => {
@@ -136,10 +135,7 @@ export function useTimeSeriesQueries(
     }
   }, [newResolved, resolvedResults]);
 
-  return results.map((result) => ({
-    ...result,
-    isFetching: result.isFetching || hasPendingDependentQueries,
-  }));
+  return results;
   // LOGZ.IO CHANGE END:: APPZ-955-math-on-queries-formulas
 }
 


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Queries now depends on the fingerprint which is built on the exact returned queries from tanstack instead of building a weak representation using string interpolation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes React Query `queryKey` composition and resolved-results state updates; incorrect reference comparisons could cause missed refetches or extra rerenders for dependent queries.
> 
> **Overview**
> Fixes dependent time-series query invalidation by switching dependency “fingerprints” from a derived string to the *actual* dependency `TimeSeriesData` references (query keys now include an array of dependency results/`undefined`).
> 
> In `useTimeSeriesQueries`, resolved-results syncing is reworked to memoize `buildResolvedResults(results)` and update state only when the map’s key/value references change via new `areMapsEqual`; adds unit coverage for `areMapsEqual` and removes the old `getResultsFingerprint` logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8c5a0c564852853d81ca17b322adfcc22ef88a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->