### PR TITLE
APPZ-1228 Support Ad Hoc Filters

### DIFF
--- a/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardStickyToolbar/DashboardStickyToolbar.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ReactElement, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import {
   AppBar,
   Box,
@@ -33,9 +33,10 @@ import { useExternalVariableDefinitions, useVariableDefinitions } from '../../co
 interface DashboardStickyToolbarProps {
   initialVariableIsSticky?: boolean;
   sx?: SxProps<Theme>;
+  toolbarAddonComponent?: ReactNode; // LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228]
 }
 
-export function DashboardStickyToolbar(props: DashboardStickyToolbarProps): ReactElement {
+export function DashboardStickyToolbar(props: DashboardStickyToolbarProps): ReactNode {
   const [isPin, setIsPin] = useState(props.initialVariableIsSticky);
 
   const scrollTrigger = useScrollTrigger({ disableHysteresis: true });
@@ -46,10 +47,6 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps): Reac
   const variableDefinitions: VariableDefinition[] = useVariableDefinitions();
   const externalVariableDefinitions: ExternalVariableDefinition[] = useExternalVariableDefinitions();
   const variablesLength = variableDefinitions.length + externalVariableDefinitions.length;
-
-  if (!variablesLength) {
-    return <></>;
-  }
 
   return (
     // marginBottom={-1} counteracts the marginBottom={1} on every variable input.
@@ -91,7 +88,8 @@ export function DashboardStickyToolbar(props: DashboardStickyToolbarProps): Reac
             }}
             gap={1}
           >
-            <VariableList />
+            {variablesLength > 0 && <VariableList />}
+            {props.toolbarAddonComponent} {/* LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228] */}
             {props.initialVariableIsSticky && (
               <IconButton style={{ width: 'fit-content', height: 'fit-content' }} onClick={() => setIsPin(!isPin)}>
                 {isPin ? <PinOutline /> : <PinOffOutline />}

--- a/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
+++ b/ui/dashboards/src/components/DashboardToolbar/DashboardToolbar.tsx
@@ -37,6 +37,7 @@ export interface DashboardToolbarProps {
   onCancelButtonClick: () => void;
   onSave?: OnSaveDashboard;
   dashboardControlsComponent?: JSX.Element;
+  toolbarAddonComponent?: ReactNode; // LOGZ.IO CHANGE:: Add support for toolbarAddonComponent
 }
 
 export const DashboardToolbar = (props: DashboardToolbarProps): ReactElement => {
@@ -51,6 +52,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps): ReactElement => 
     onCancelButtonClick,
     onSave,
     dashboardControlsComponent,
+    toolbarAddonComponent,
   } = props;
 
   const { isEditMode } = useEditMode();
@@ -121,6 +123,7 @@ export const DashboardToolbar = (props: DashboardToolbarProps): ReactElement => 
           <Box width="100%">
             <ErrorBoundary FallbackComponent={ErrorAlert}>
               <DashboardStickyToolbar
+                toolbarAddonComponent={toolbarAddonComponent} // LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228]
                 initialVariableIsSticky={initialVariableIsSticky}
                 sx={{
                   backgroundColor: ({ palette }) => palette.background.default,

--- a/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/DashboardApp.tsx
@@ -43,6 +43,7 @@ export interface DashboardAppProps {
   // If true, browser confirmation dialog will be shown when navigating away with unsaved changes (closing tab, ...).
   isLeavingConfirmDialogEnabled?: boolean;
   dashboardTitleComponent?: ReactNode;
+  toolbarAddonComponent?: ReactNode; // LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228]
   onSave?: OnSaveDashboard;
   onDiscard?: (entity: DashboardResource) => void;
   onDashboardChange?: (dashboard: DashboardResource) => void; // LOGZ.IO CHANGE:: Alert users when trying to navigate out of dashboard in edit mode that has changes [APPZ-316]
@@ -62,6 +63,7 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
     onSave,
     onDiscard,
     dashboardControlsComponent, // LOGZ.IO CHANGE:: Add support for dashboardControlsComponent
+    toolbarAddonComponent, // LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228]
     onDashboardChange, // LOGZ.IO CHANGE:: Alert users when trying to navigate out of dashboard in edit mode that has changes [APPZ-316]
   } = props;
 
@@ -138,6 +140,7 @@ export const DashboardApp = (props: DashboardAppProps): ReactElement => {
         onEditButtonClick={onEditButtonClick}
         onCancelButtonClick={onCancelButtonClick}
         dashboardControlsComponent={dashboardControlsComponent}
+        toolbarAddonComponent={toolbarAddonComponent} // LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228]
       />
       <Box
         sx={{

--- a/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
+++ b/ui/dashboards/src/views/ViewDashboard/ViewDashboard.tsx
@@ -62,6 +62,7 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
     dashboardStoreApiRef,
     onDashboardChange, // LOGZ.IO CHANGE:: Alert users when trying to navigate out of dashboard in edit mode that has changes [APPZ-316]
     dashboardControlsComponent, // LOGZ.IO CHANGE:: Add support for dashboardControlsComponent
+    toolbarAddonComponent, // LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228]
     ...others
   } = props;
   const { spec } = dashboardResource;
@@ -153,6 +154,7 @@ export function ViewDashboard(props: ViewDashboardProps): ReactElement {
                   isDatasourceEnabled={isDatasourceEnabled}
                   isCreating={isCreating}
                   dashboardControlsComponent={dashboardControlsComponent}
+                  toolbarAddonComponent={toolbarAddonComponent} // LOGZ.IO CHANGE:: Support AdHoc filters [APPZ-1228]
                   isInitialVariableSticky={isInitialVariableSticky}
                   isLeavingConfirmDialogEnabled={isLeavingConfirmDialogEnabled}
                   dashboardTitleComponent={dashboardTitleComponent}


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Attached to https://github.com/logzio/gaia-hermes-ws/pull/16009

Added support to pass externally a addon for the filter bar. this will be eventually used by us to render the ad-hoc filters on gaia-hermes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only prop plumbing and conditional rendering changes; low risk, with the main concern being minor layout/regression when dashboards have zero variables.
> 
> **Overview**
> Enables consumers to inject additional UI into the dashboard’s variable/sticky toolbar via a new optional `toolbarAddonComponent` prop, wired through `ViewDashboard` → `DashboardApp` → `DashboardToolbar` → `DashboardStickyToolbar`.
> 
> Adjusts `DashboardStickyToolbar` to always render the toolbar container, conditionally render `VariableList` only when variables exist, and place the injected addon alongside variables/pin control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c0031740efd1bc9fecc6a3a550cbef4e67edf86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->