### PR TITLE
APPZ-2123 Prom ql editor bugs in unified dashboards variables editor

### DIFF
--- a/ui/core/src/schema/variable.ts
+++ b/ui/core/src/schema/variable.ts
@@ -33,7 +33,7 @@ export const variableDisplaySchema: z.ZodSchema<VariableDisplay> = z.object({
 export const variableListSpecSchema: z.ZodSchema<ListVariableSpec> = z.object({
   name: z.string().min(1),
   display: variableDisplaySchema.optional(),
-  defaultValue: z.string().or(z.array(z.string())).optional(),
+  defaultValue: z.string().or(z.array(z.string())).nullable().optional(),
   allowAllValue: z.boolean(),
   allowMultiple: z.boolean(),
   customAllValue: z.string().optional(),
@@ -56,7 +56,7 @@ export function buildVariableListSpecSchema(pluginSchema: PluginSchema): z.ZodSc
   return z.object({
     name: z.string().min(1),
     display: variableDisplaySchema.optional(),
-    defaultValue: z.string().or(z.array(z.string())).optional(),
+    defaultValue: z.string().or(z.array(z.string())).nullable().optional(),
     allowAllValue: z.boolean(),
     allowMultiple: z.boolean(),
     customAllValue: z.string().optional(),


### PR DESCRIPTION
the TypeScript type VariableValue already defined defaultValue as string | string[] | null, but the Zod validation schema only accepted string | string[] | undefined. Adding .nullable() brings the schema in line with the type, allowing prod variables that have defaultValue: null to pass validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small schema-validation change limited to variable parsing; low risk aside from slightly broader acceptance of input data.
> 
> **Overview**
> Allows `ListVariableSpec.defaultValue` to be explicitly `null` (in addition to a string/string array or being omitted) in both `variableListSpecSchema` and `buildVariableListSpecSchema`, preventing validation failures when persisted variables store `defaultValue: null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4910905a54d4477ce94f7bc0050452dbfdbd7c4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->