### PR TITLE
APPZ-1234 UniDash - Hot fixes

### DIFF
--- a/ui/components/src/Table/VirtualizedTable.tsx
+++ b/ui/components/src/Table/VirtualizedTable.tsx
@@ -98,7 +98,15 @@ export function VirtualizedTable<TableData>({
     return {
       Scroller: VirtualizedTableContainer,
       Table: (props): ReactElement => {
-        return <InnerTable {...props} width={width} density={density} onKeyDown={keyboardNav.onTableKeyDown} />;
+        return (
+          <InnerTable
+            {...props}
+            width={width}
+            density={density}
+            onKeyDown={keyboardNav.onTableKeyDown}
+            onBlur={keyboardNav.onTableBlur}
+          />
+        );
       },
       TableHead,
       TableFoot,
@@ -128,7 +136,16 @@ export function VirtualizedTable<TableData>({
       },
       TableBody,
     };
-  }, [density, keyboardNav.onTableKeyDown, onRowClick, onRowMouseOut, onRowMouseOver, rows, width]);
+  }, [
+    density,
+    keyboardNav.onTableKeyDown,
+    keyboardNav.onTableBlur,
+    onRowClick,
+    onRowMouseOut,
+    onRowMouseOver,
+    rows,
+    width,
+  ]);
 
   const handleChangePage = (_event: React.MouseEvent<HTMLButtonElement> | null, newPage: number): void => {
     if (!pagination || !onPaginationChange) return;

--- a/ui/components/src/Table/hooks/useTableKeyboardNav.tsx
+++ b/ui/components/src/Table/hooks/useTableKeyboardNav.tsx
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { KeyboardEventHandler, useCallback, useState } from 'react';
+import { FocusEventHandler, KeyboardEventHandler, useCallback, useState } from 'react';
 
 export interface UseTableKeyboardNavProps {
   maxRows: number;
@@ -59,6 +59,7 @@ export function useTableKeyboardNav({ maxRows, maxColumns, onActiveCellChange }:
   isActive: boolean;
   onTableKeyDown: KeyboardEventHandler<HTMLTableElement>;
   onCellFocus: (cellPosition: TableCellPosition) => void;
+  onTableBlur: FocusEventHandler<HTMLTableElement>;
 } {
   const [activeCell, setActiveCell] = useState<TableCellPosition>(DEFAULT_ACTIVE_CELL);
   const [isActive, setIsActive] = useState(false);
@@ -122,10 +123,18 @@ export function useTableKeyboardNav({ maxRows, maxColumns, onActiveCellChange }:
     [maxColumns, maxRows, onActiveCellChange]
   );
 
+  const handleTableBlur: FocusEventHandler<HTMLTableElement> = useCallback((e) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsActive(false);
+      setActiveCell(DEFAULT_ACTIVE_CELL);
+    }
+  }, []);
+
   return {
     activeCell,
     isActive,
     onTableKeyDown: handleKeyDown,
     onCellFocus: handleCellFocus,
+    onTableBlur: handleTableBlur,
   };
 }

--- a/ui/components/src/Table/hooks/useVirtualizedTableKeyboardNav.tsx
+++ b/ui/components/src/Table/hooks/useVirtualizedTableKeyboardNav.tsx
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 import { TableVirtuosoHandle } from 'react-virtuoso';
-import { KeyboardEventHandler, MutableRefObject, RefObject } from 'react';
+import { FocusEventHandler, KeyboardEventHandler, MutableRefObject, RefObject } from 'react';
 import { useTableKeyboardNav, UseTableKeyboardNavProps } from './useTableKeyboardNav';
 
 interface UseVirtualizedTableKeyboardNavProps extends Omit<UseTableKeyboardNavProps, 'onActiveCellChange'> {
@@ -43,6 +43,7 @@ export function useVirtualizedTableKeyboardNav({
   isActive: boolean;
   onTableKeyDown: KeyboardEventHandler<HTMLTableElement>;
   onCellFocus: (cellPosition: TableCellPosition) => void;
+  onTableBlur: FocusEventHandler<HTMLTableElement>;
 } {
   const baseKeyboard = useTableKeyboardNav({
     maxRows,

--- a/ui/core/src/model/definitions.ts
+++ b/ui/core/src/model/definitions.ts
@@ -17,7 +17,6 @@
 export interface Definition<Spec> {
   kind: string;
   spec: Spec;
-  hidden?: boolean; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 
 /**

--- a/ui/core/src/model/query.ts
+++ b/ui/core/src/model/query.ts
@@ -19,12 +19,6 @@ import { LogData } from './log-data';
 
 interface QuerySpec<PluginSpec> {
   plugin: Definition<PluginSpec>;
-  /**
-   * When true, the query result is hidden from chart visualization but still executes.
-   * Hidden queries can still be referenced by other queries (e.g., Math expressions).
-   * Defaults to false (visible).
-   */
-  hidden?: boolean; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 /**
  * A generic query definition interface that can be extended to support more than just TimeSeriesQuery
@@ -34,6 +28,7 @@ interface QuerySpec<PluginSpec> {
 export interface QueryDefinition<Kind = any, PluginSpec = UnknownSpec> {
   kind: Kind;
   spec: QuerySpec<PluginSpec>;
+  hidden?: boolean; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 
 /**

--- a/ui/core/src/model/variables.ts
+++ b/ui/core/src/model/variables.ts
@@ -58,9 +58,7 @@ export interface BuiltinVariableDefinition extends Definition<BuiltinVariableSpe
 export interface BuiltinVariableSpec extends VariableSpec {
   value: () => string;
   source: string;
-  // LOGZ.IO CHANGE START:: unidash add tooltips to make features more clear to users [APPZ-348]
-  sourceDescription?: string;
-  // LOGZ.IO CHANGE END:: unidash add tooltips to make features more clear to users [APPZ-348]
+  sourceDescription?: string; // LOGZ.IO CHANGE:: unidash add tooltips to make features more clear to users [APPZ-348]
 }
 
 export type VariableDefinition = TextVariableDefinition | ListVariableDefinition;

--- a/ui/core/src/schema/panel.ts
+++ b/ui/core/src/schema/panel.ts
@@ -24,8 +24,8 @@ export const querySpecSchema: z.ZodSchema<QueryDefinition> = z.object({
   kind: z.string().min(1),
   spec: z.object({
     plugin: pluginSchema,
-    hidden: z.boolean().optional(), // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
   }),
+  hidden: z.boolean().optional(), // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 });
 
 export const linkSchema: z.ZodSchema<Link> = z.object({

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -90,7 +90,7 @@ export function GridItemContent(props: GridItemContentProps): ReactElement {
         return {
           kind: query.spec.plugin.kind,
           spec: query.spec.plugin.spec,
-          hidden: query.spec.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
+          hidden: query.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
         };
       }),
     [queries]

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -30,6 +30,7 @@ export interface PanelContentProps extends Omit<PanelProps<UnknownSpec>, 'queryR
  */
 export function PanelContent(props: PanelContentProps): ReactElement {
   const { panelPluginKind, definition, queryResults, spec, contentDimensions } = props;
+  console.log('🚀 ~ PanelContent ~ queryResults:', queryResults);
   const { data: plugin, isLoading: isPanelLoading } = usePlugin('Panel', panelPluginKind, { throwOnError: true }); // LOGZIO CHANGE: `useErrorBoundary` was changed to `throwOnError` for tanstack query v4 -> v5 support
 
   // Render the panel if any query has data, or the panel doesn't have a query attached (for example MarkdownPanel).
@@ -37,15 +38,13 @@ export function PanelContent(props: PanelContentProps): ReactElement {
   const queryResultsWithData = useMemo(
     () =>
       queryResults.flatMap((q) =>
-        q.data && !q.definition?.spec?.hidden ? [{ data: q.data, definition: q.definition }] : []
+        q.data && !q.definition?.hidden ? [{ data: q.data, definition: q.definition }] : []
       ),
     [queryResults]
   );
+  console.log('🚀 ~ PanelContent ~ queryResultsWithData:', queryResultsWithData);
 
-  const areAllQueriesHidden = useMemo(
-    () => queryResults.every((q) => q.definition?.spec?.hidden ?? false),
-    [queryResults]
-  );
+  const areAllQueriesHidden = useMemo(() => queryResults.every((q) => q.definition?.hidden ?? false), [queryResults]);
 
   // Show fullsize skeleton if the panel plugin is loading.
   if (isPanelLoading) {

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -30,7 +30,6 @@ export interface PanelContentProps extends Omit<PanelProps<UnknownSpec>, 'queryR
  */
 export function PanelContent(props: PanelContentProps): ReactElement {
   const { panelPluginKind, definition, queryResults, spec, contentDimensions } = props;
-  console.log('🚀 ~ PanelContent ~ queryResults:', queryResults);
   const { data: plugin, isLoading: isPanelLoading } = usePlugin('Panel', panelPluginKind, { throwOnError: true }); // LOGZIO CHANGE: `useErrorBoundary` was changed to `throwOnError` for tanstack query v4 -> v5 support
 
   // Render the panel if any query has data, or the panel doesn't have a query attached (for example MarkdownPanel).

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -41,7 +41,6 @@ export function PanelContent(props: PanelContentProps): ReactElement {
       ),
     [queryResults]
   );
-  console.log('🚀 ~ PanelContent ~ queryResultsWithData:', queryResultsWithData);
 
   const areAllQueriesHidden = useMemo(() => queryResults.every((q) => q.definition?.hidden ?? false), [queryResults]);
 

--- a/ui/dashboards/src/components/PanelDrawer/PanelQueriesSharedControls.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelQueriesSharedControls.tsx
@@ -54,7 +54,7 @@ export function PanelQueriesSharedControls({
       return {
         kind: query.spec.plugin.kind,
         spec: query.spec.plugin.spec,
-        hidden: query.spec.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
+        hidden: query.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
       };
     }) ?? [];
 

--- a/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
@@ -133,7 +133,7 @@ export const MultiQueryEditor = forwardRef<PluginEditorRef, MultiQueryEditorProp
         produce(queries, (draft) => {
           const entry = draft?.[index];
           if (entry) {
-            entry.spec.hidden = !isHidden;
+            entry.hidden = !isHidden;
           }
         })
       );
@@ -169,7 +169,7 @@ export const MultiQueryEditor = forwardRef<PluginEditorRef, MultiQueryEditorProp
             queryResult={queryResults?.[i]}
             filteredQueryPlugins={filteredQueryPlugins}
             isCollapsed={!!queriesCollapsed[i]}
-            isHidden={query.spec.hidden ?? false}
+            isHidden={query.hidden ?? false}
             onChange={handleQueryChange}
             onDelete={queries.length > 1 ? handleQueryDelete : undefined}
             onVisibilityToggle={handleVisibilityToggle}

--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
@@ -89,7 +89,7 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
               <Typography variant="overline" component="h4">
                 Query #{index + 1}
               </Typography>
-              {query.spec.hidden && (
+              {query.hidden && (
                 <Typography variant="caption" color="secondary" component="span" fontStyle="italic">
                   Disabled
                 </Typography>

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -82,8 +82,8 @@ export function DataQueriesProvider(props: DataQueriesProviderProps): ReactEleme
           kind: type,
           spec: {
             plugin: definition,
-            hidden: definition.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
           },
+          hidden: definition.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
         };
       }),
     [definitions, getQueryType]

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/model.ts
@@ -18,7 +18,7 @@ import { useListPluginMetadata } from '../plugin-registry';
 
 export type QueryOptions = Record<string, unknown>;
 export interface DataQueriesProviderProps<QueryPluginSpec = UnknownSpec> {
-  definitions: Array<Definition<QueryPluginSpec>>;
+  definitions: Array<Definition<QueryPluginSpec> & { hidden?: boolean }>; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
   children?: ReactNode;
   options?: QueryOptions;
   queryOptions?: Omit<QueryObserverOptions, 'queryKey'>;

--- a/ui/plugin-system/src/runtime/time-series-queries-utils.ts
+++ b/ui/plugin-system/src/runtime/time-series-queries-utils.ts
@@ -39,7 +39,10 @@ export function getQueryOptions(
 
   const filteredVariabledState = filterVariableStateMap(variableState, variableDependencies);
   const variablesValueKey = getVariableValuesKey(filteredVariabledState);
-  const definitionQueryKey: TimeSeriesQueryDefinition = { ...definition, spec: { plugin: definition.spec.plugin } };
+  const definitionQueryKey: TimeSeriesQueryDefinition = {
+    kind: definition.kind,
+    spec: definition.spec,
+  };
 
   const queryKey = [
     'query',


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
connected to https://github.com/logzio/gaia-hermes-ws/pull/16034
- Unifying solutions matching perses before upgrade
- Bug fix related to table component 

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes propagate a `hidden` flag through query definitions and schema, which can affect which queries render/execute across dashboards and plugins. Table blur handling is localized and low risk, but the query model change could cause subtle compatibility issues if any code still expects `spec.hidden`.
> 
> **Overview**
> Fixes virtualized table keyboard navigation by adding an `onBlur` handler that clears the active cell state when focus leaves the table, and wires it through `VirtualizedTable`/`useTableKeyboardNav`.
> 
> Normalizes the *query visibility* (`hidden`) field by moving it from `QueryDefinition.spec.hidden` to `QueryDefinition.hidden` and updating the Zod `querySpecSchema`, dashboard panel/query plumbing, `MultiQueryEditor`, and `DataQueriesProvider` typings/logic accordingly. Also simplifies the time-series query cache key construction and removes the unused `hidden` field from the generic `Definition` type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36e1863bb6325ed32acc79dc93a5deff61fd8535. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->