### PR TITLE
APPZ-1234 Move hidden back to spec

### DIFF
--- a/ui/core/src/model/query.ts
+++ b/ui/core/src/model/query.ts
@@ -19,6 +19,7 @@ import { LogData } from './log-data';
 
 interface QuerySpec<PluginSpec> {
   plugin: Definition<PluginSpec>;
+  hidden?: boolean; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 /**
  * A generic query definition interface that can be extended to support more than just TimeSeriesQuery
@@ -28,7 +29,6 @@ interface QuerySpec<PluginSpec> {
 export interface QueryDefinition<Kind = any, PluginSpec = UnknownSpec> {
   kind: Kind;
   spec: QuerySpec<PluginSpec>;
-  hidden?: boolean; // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 }
 
 /**

--- a/ui/core/src/schema/panel.ts
+++ b/ui/core/src/schema/panel.ts
@@ -24,8 +24,8 @@ export const querySpecSchema: z.ZodSchema<QueryDefinition> = z.object({
   kind: z.string().min(1),
   spec: z.object({
     plugin: pluginSchema,
+    hidden: z.boolean().optional(), // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
   }),
-  hidden: z.boolean().optional(), // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
 });
 
 export const linkSchema: z.ZodSchema<Link> = z.object({

--- a/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
+++ b/ui/dashboards/src/components/GridLayout/GridItemContent.tsx
@@ -90,7 +90,7 @@ export function GridItemContent(props: GridItemContentProps): ReactElement {
         return {
           kind: query.spec.plugin.kind,
           spec: query.spec.plugin.spec,
-          hidden: query.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
+          hidden: query.spec.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
         };
       }),
     [queries]

--- a/ui/dashboards/src/components/Panel/PanelContent.tsx
+++ b/ui/dashboards/src/components/Panel/PanelContent.tsx
@@ -37,12 +37,15 @@ export function PanelContent(props: PanelContentProps): ReactElement {
   const queryResultsWithData = useMemo(
     () =>
       queryResults.flatMap((q) =>
-        q.data && !q.definition?.hidden ? [{ data: q.data, definition: q.definition }] : []
+        q.data && !q.definition?.spec.hidden ? [{ data: q.data, definition: q.definition }] : []
       ),
     [queryResults]
   );
 
-  const areAllQueriesHidden = useMemo(() => queryResults.every((q) => q.definition?.hidden ?? false), [queryResults]);
+  const areAllQueriesHidden = useMemo(
+    () => queryResults.every((q) => q.definition?.spec.hidden ?? false),
+    [queryResults]
+  );
 
   // Show fullsize skeleton if the panel plugin is loading.
   if (isPanelLoading) {

--- a/ui/dashboards/src/components/PanelDrawer/PanelQueriesSharedControls.tsx
+++ b/ui/dashboards/src/components/PanelDrawer/PanelQueriesSharedControls.tsx
@@ -54,7 +54,7 @@ export function PanelQueriesSharedControls({
       return {
         kind: query.spec.plugin.kind,
         spec: query.spec.plugin.spec,
-        hidden: query.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
+        hidden: query.spec.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
       };
     }) ?? [];
 

--- a/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/MultiQueryEditor.tsx
@@ -133,7 +133,7 @@ export const MultiQueryEditor = forwardRef<PluginEditorRef, MultiQueryEditorProp
         produce(queries, (draft) => {
           const entry = draft?.[index];
           if (entry) {
-            entry.hidden = !isHidden;
+            entry.spec.hidden = !isHidden;
           }
         })
       );
@@ -169,7 +169,7 @@ export const MultiQueryEditor = forwardRef<PluginEditorRef, MultiQueryEditorProp
             queryResult={queryResults?.[i]}
             filteredQueryPlugins={filteredQueryPlugins}
             isCollapsed={!!queriesCollapsed[i]}
-            isHidden={query.hidden ?? false}
+            isHidden={query.spec.hidden ?? false}
             onChange={handleQueryChange}
             onDelete={queries.length > 1 ? handleQueryDelete : undefined}
             onVisibilityToggle={handleVisibilityToggle}

--- a/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
+++ b/ui/plugin-system/src/components/MultiQueryEditor/QueryEditorContainer.tsx
@@ -89,7 +89,7 @@ export const QueryEditorContainer = forwardRef<PluginEditorRef, QueryEditorConta
               <Typography variant="overline" component="h4">
                 Query #{index + 1}
               </Typography>
-              {query.hidden && (
+              {isHidden && (
                 <Typography variant="caption" color="secondary" component="span" fontStyle="italic">
                   Disabled
                 </Typography>

--- a/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
+++ b/ui/plugin-system/src/runtime/DataQueriesProvider/DataQueriesProvider.tsx
@@ -82,8 +82,8 @@ export function DataQueriesProvider(props: DataQueriesProviderProps): ReactEleme
           kind: type,
           spec: {
             plugin: definition,
+            hidden: definition.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
           },
-          hidden: definition.hidden ?? false, // LOGZ.IO CHANGE:: APPZ-955-math-on-queries-formulas
         };
       }),
     [definitions, getQueryType]


### PR DESCRIPTION
<!--
  See the contributing guide for detailed guidance about contributing.
  https://github.com/perses/perses/blob/main/CONTRIBUTING.md
-->

# Description
Perses wants the hidden within the spec so im reverting it back to being there.

<!-- Context useful to a reviewer -->

# Screenshots

<!-- If there are UI changes -->

# Checklist

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Pull request title follows the `[<catalog_entry>] <commit message>` naming convention using one of the
  following `catalog_entry` values: `FEATURE`, `ENHANCEMENT`, `BUGFIX`, `BREAKINGCHANGE`, `DOC`,`IGNORE`.
- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works).

## UI Changes

- [ ] Changes that impact the UI include screenshots and/or screencasts of the relevant changes.
- [ ] Code follows the [UI guidelines](https://github.com/perses/perses/blob/main/ui/ui-guidelines.md).
- [ ] Visual tests are stable and unlikely to be flaky.
  See [e2e](https://github.com/perses/perses/tree/main/ui/e2e#visual-tests) docs for more details. Common issues include:
  - Is the data inconsistent? You need to mock API requests.
  - Does the time change? You need to use consistent time values or mock time utilities.
  - Does it have loading states? You need to wait for loading to complete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, mechanical shape change to query definitions; risk is limited to regressions in query visibility/disable behavior if any caller still expects top-level `hidden`.
> 
> **Overview**
> Moves the per-query `hidden` flag back under `QueryDefinition.spec` and updates the Zod schema accordingly.
> 
> Updates dashboard rendering and editing flows to read/write `spec.hidden` (query visibility toggle, “Disabled” label, and panel rendering logic that filters hidden queries) and ensures `DataQueriesProvider` populates `spec.hidden` when constructing runtime query definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04ecbcf9843538fcd07ee6106c7a7bb88721aa0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->